### PR TITLE
Add top 10 reusable DBT macros for Alteryx migration

### DIFF
--- a/dbt_macros/date_spine.sql
+++ b/dbt_macros/date_spine.sql
@@ -1,0 +1,193 @@
+{#
+    Macro: date_spine
+    Description: Generates a continuous date series between start and end dates.
+
+    Alteryx Equivalent: Generate Rows tool for date sequences
+    Trino Compatible: Yes (uses sequence() and unnest())
+
+    Arguments:
+        start_date: Start date (can be literal 'YYYY-MM-DD' or date expression)
+        end_date: End date (can be literal 'YYYY-MM-DD' or date expression)
+        date_column: Name for the output date column (default: 'date_day')
+
+    Example Usage:
+        {{ date_spine(
+            start_date="date '2024-01-01'",
+            end_date="date '2024-12-31'",
+            date_column='calendar_date'
+        ) }}
+
+    Output: One row per day from start_date to end_date (inclusive)
+#}
+
+{% macro date_spine(start_date, end_date, date_column='date_day') %}
+
+select
+    cast({{ date_column }} as date) as {{ date_column }}
+from unnest(
+    sequence(
+        {{ start_date }},
+        {{ end_date }},
+        interval '1' day
+    )
+) as t({{ date_column }})
+
+{% endmacro %}
+
+
+{#
+    Macro: date_spine_with_attributes
+    Description: Generates date spine with common date attributes (day of week, month, quarter, etc.).
+
+    Alteryx Equivalent: Generate Rows + DateTime tool
+
+    Arguments:
+        start_date: Start date
+        end_date: End date
+        date_column: Name for the date column (default: 'date_day')
+
+    Output columns: date_day, day_of_week, day_of_month, day_of_year, week_of_year,
+                    month_num, month_name, quarter, year, is_weekend, is_month_start, is_month_end
+#}
+
+{% macro date_spine_with_attributes(start_date, end_date, date_column='date_day') %}
+
+with base_dates as (
+    {{ date_spine(start_date, end_date, date_column) }}
+)
+
+select
+    {{ date_column }},
+    day_of_week({{ date_column }}) as day_of_week,
+    day_of_month({{ date_column }}) as day_of_month,
+    day_of_year({{ date_column }}) as day_of_year,
+    week_of_year({{ date_column }}) as week_of_year,
+    month({{ date_column }}) as month_num,
+    format_datetime({{ date_column }}, 'MMMM') as month_name,
+    quarter({{ date_column }}) as quarter,
+    year({{ date_column }}) as year,
+    case when day_of_week({{ date_column }}) in (6, 7) then true else false end as is_weekend,
+    case when day_of_month({{ date_column }}) = 1 then true else false end as is_month_start,
+    case when {{ date_column }} = last_day_of_month({{ date_column }}) then true else false end as is_month_end,
+    date_trunc('week', {{ date_column }}) as week_start,
+    date_trunc('month', {{ date_column }}) as month_start,
+    date_trunc('quarter', {{ date_column }}) as quarter_start,
+    date_trunc('year', {{ date_column }}) as year_start
+from base_dates
+
+{% endmacro %}
+
+
+{#
+    Macro: timestamp_spine
+    Description: Generates a continuous timestamp series at specified intervals.
+
+    Arguments:
+        start_timestamp: Start timestamp
+        end_timestamp: End timestamp
+        interval_unit: 'minute', 'hour', 'day' (default: 'hour')
+        interval_value: Number of units between each timestamp (default: 1)
+        timestamp_column: Output column name (default: 'timestamp_value')
+#}
+
+{% macro timestamp_spine(start_timestamp, end_timestamp, interval_unit='hour', interval_value=1, timestamp_column='timestamp_value') %}
+
+select
+    {{ timestamp_column }}
+from unnest(
+    sequence(
+        {{ start_timestamp }},
+        {{ end_timestamp }},
+        interval '{{ interval_value }}' {{ interval_unit }}
+    )
+) as t({{ timestamp_column }})
+
+{% endmacro %}
+
+
+{#
+    Macro: fill_date_gaps
+    Description: Fills gaps in a date series by cross-joining with date spine.
+
+    Alteryx Equivalent: Append Fields with date dimension + Filter/Join
+
+    Arguments:
+        relation: Source relation with dates
+        date_column: Date column in source
+        min_date: Minimum date (optional, derives from data if not specified)
+        max_date: Maximum date (optional, derives from data if not specified)
+        group_columns: Columns to carry forward for each date (for SCD-style fills)
+        fill_method: 'null' (leave nulls), 'forward' (LOCF), 'zero' (fill numerics with 0)
+#}
+
+{% macro fill_date_gaps(relation, date_column, min_date=none, max_date=none, group_columns=none, fill_method='null') %}
+
+{%- set min_dt = min_date if min_date else '(select min(' ~ date_column ~ ') from ' ~ relation ~ ')' -%}
+{%- set max_dt = max_date if max_date else '(select max(' ~ date_column ~ ') from ' ~ relation ~ ')' -%}
+
+with date_range as (
+    {{ date_spine(min_dt, max_dt, date_column) }}
+),
+
+{% if group_columns %}
+groups as (
+    select distinct {{ group_columns | join(', ') }}
+    from {{ relation }}
+),
+
+scaffolding as (
+    select
+        d.{{ date_column }},
+        {{ group_columns | join(', ') }}
+    from date_range d
+    cross join groups
+)
+{% else %}
+scaffolding as (
+    select {{ date_column }}
+    from date_range
+)
+{% endif %}
+
+select
+    s.*,
+    {%- set other_columns = adapter.get_columns_in_relation(relation) %}
+    {%- for col in other_columns %}
+        {%- if col.name != date_column and (not group_columns or col.name not in group_columns) %}
+    r.{{ col.name }}{% if not loop.last %},{% endif %}
+        {%- endif %}
+    {%- endfor %}
+from scaffolding s
+left join {{ relation }} r
+    on s.{{ date_column }} = r.{{ date_column }}
+    {% if group_columns %}
+    {%- for gc in group_columns %}
+    and s.{{ gc }} = r.{{ gc }}
+    {%- endfor %}
+    {% endif %}
+
+{% endmacro %}
+
+
+{#
+    Macro: date_diff_days
+    Description: Calculates the difference in days between two dates.
+
+    Alteryx Equivalent: DateTimeDiff([date1], [date2], 'days')
+#}
+
+{% macro date_diff_days(date1, date2) %}
+date_diff('day', {{ date2 }}, {{ date1 }})
+{% endmacro %}
+
+
+{#
+    Macro: add_days
+    Description: Adds days to a date.
+
+    Alteryx Equivalent: DateTimeAdd([date], [days], 'days')
+#}
+
+{% macro add_days(date_column, days) %}
+date_add('day', {{ days }}, {{ date_column }})
+{% endmacro %}

--- a/dbt_macros/deduplicate.sql
+++ b/dbt_macros/deduplicate.sql
@@ -1,0 +1,73 @@
+{#
+    Macro: deduplicate
+    Description: Removes duplicate rows based on partition columns, keeping one row per partition.
+
+    Alteryx Equivalent: Unique tool, or RecordID + Filter combination
+    Trino Compatible: Yes
+
+    Arguments:
+        relation: The source relation (table/CTE)
+        partition_by: List of columns to partition by (defines uniqueness)
+        order_by: List of columns to order by within each partition (determines which row to keep)
+        order_direction: 'asc' or 'desc' (default: 'desc' to keep most recent)
+
+    Example Usage:
+        {{ deduplicate(
+            relation=ref('stg_customers'),
+            partition_by=['customer_id'],
+            order_by=['updated_at'],
+            order_direction='desc'
+        ) }}
+
+    Output: Single row per partition_by combination, ordered by order_by columns
+#}
+
+{% macro deduplicate(relation, partition_by, order_by, order_direction='desc') %}
+
+with dedupe_ranked as (
+    select
+        *,
+        row_number() over (
+            partition by {{ partition_by | join(', ') }}
+            order by {{ order_by | join(' ' ~ order_direction ~ ', ') }} {{ order_direction }}
+        ) as _dedupe_row_num
+    from {{ relation }}
+)
+
+select
+    {%- set columns = adapter.get_columns_in_relation(relation) %}
+    {%- for column in columns %}
+    {{ column.name }}{% if not loop.last %},{% endif %}
+    {%- endfor %}
+from dedupe_ranked
+where _dedupe_row_num = 1
+
+{% endmacro %}
+
+
+{#
+    Macro: deduplicate_simple
+    Description: Simple deduplication using DISTINCT - faster but less control
+
+    Alteryx Equivalent: Unique tool (basic mode)
+
+    Arguments:
+        relation: The source relation
+        columns: List of columns to include (uses all if not specified)
+
+    Example Usage:
+        {{ deduplicate_simple(ref('stg_orders'), ['customer_id', 'product_id']) }}
+#}
+
+{% macro deduplicate_simple(relation, columns=none) %}
+
+{% if columns %}
+select distinct
+    {{ columns | join(', ') }}
+from {{ relation }}
+{% else %}
+select distinct *
+from {{ relation }}
+{% endif %}
+
+{% endmacro %}

--- a/dbt_macros/generate_surrogate_key.sql
+++ b/dbt_macros/generate_surrogate_key.sql
@@ -1,0 +1,123 @@
+{#
+    Macro: generate_surrogate_key
+    Description: Generates a surrogate key (hash) from one or more columns.
+
+    Alteryx Equivalent: Formula tool with MD5_ASCII() or SHA256() function
+    Trino Compatible: Yes (uses xxhash64 or md5)
+
+    Arguments:
+        columns: List of column names to include in the hash
+        hash_function: 'xxhash64' (faster) or 'md5' (more common) (default: 'md5')
+
+    Example Usage:
+        select
+            {{ generate_surrogate_key(['customer_id', 'order_date']) }} as order_key,
+            *
+        from {{ ref('stg_orders') }}
+
+    Note: This is similar to dbt_utils.generate_surrogate_key but uses Trino-native functions
+#}
+
+{% macro generate_surrogate_key(columns, hash_function='md5') %}
+
+{% if hash_function == 'xxhash64' %}
+cast(xxhash64(to_utf8(concat(
+    {%- for column in columns %}
+    coalesce(cast({{ column }} as varchar), '_null_')
+    {%- if not loop.last %}, '|', {% endif %}
+    {%- endfor %}
+))) as varchar)
+{% else %}
+to_hex(md5(to_utf8(concat(
+    {%- for column in columns %}
+    coalesce(cast({{ column }} as varchar), '_null_')
+    {%- if not loop.last %}, '|', {% endif %}
+    {%- endfor %}
+))))
+{% endif %}
+
+{% endmacro %}
+
+
+{#
+    Macro: generate_record_id
+    Description: Adds a unique sequential record ID to each row.
+
+    Alteryx Equivalent: RecordID tool
+
+    Arguments:
+        relation: The source relation
+        id_alias: Name for the ID column (default: 'record_id')
+        start_value: Starting value for the sequence (default: 1)
+        order_by: Optional columns to determine ID order
+
+    Example Usage:
+        {{ generate_record_id(
+            relation=ref('stg_customers'),
+            id_alias='customer_sequence',
+            order_by=['created_at']
+        ) }}
+#}
+
+{% macro generate_record_id(relation, id_alias='record_id', start_value=1, order_by=none) %}
+
+select
+    row_number() over (
+        {% if order_by %}
+        order by {{ order_by | join(', ') }}
+        {% else %}
+        order by (select null)
+        {% endif %}
+    ) + {{ start_value - 1 }} as {{ id_alias }},
+    *
+from {{ relation }}
+
+{% endmacro %}
+
+
+{#
+    Macro: generate_uuid
+    Description: Generates a UUID for each row.
+
+    Alteryx Equivalent: Formula tool with UUID generation
+    Trino Compatible: Yes (uses uuid() function)
+
+    Arguments:
+        alias: Name for the UUID column (default: 'uuid')
+#}
+
+{% macro generate_uuid(alias='uuid') %}
+cast(uuid() as varchar) as {{ alias }}
+{% endmacro %}
+
+
+{#
+    Macro: add_metadata_columns
+    Description: Adds common metadata columns (load timestamp, source file, hash key).
+
+    Alteryx Equivalent: Adding audit/metadata columns via Formula tool
+
+    Arguments:
+        relation: The source relation
+        include_load_ts: Add load timestamp column (default: true)
+        include_source_file: Add source file column if available (default: false)
+        include_row_hash: Add hash of all columns (default: false)
+        key_columns: Columns for surrogate key (optional, used with include_row_hash)
+#}
+
+{% macro add_metadata_columns(relation, include_load_ts=true, include_source_file=false, include_row_hash=false, key_columns=none) %}
+
+select
+    *
+    {%- if include_load_ts %},
+    current_timestamp as _loaded_at
+    {%- endif %}
+    {%- if include_source_file %},
+    '{{ this.identifier }}' as _source_model
+    {%- endif %}
+    {%- if include_row_hash and key_columns %},
+    {{ generate_surrogate_key(key_columns) }} as _row_hash
+    {%- endif %}
+from {{ relation }}
+
+{% endmacro %}

--- a/dbt_macros/null_if_empty.sql
+++ b/dbt_macros/null_if_empty.sql
@@ -1,0 +1,157 @@
+{#
+    Macro: null_if_empty
+    Description: Converts empty strings and whitespace-only strings to NULL.
+
+    Alteryx Equivalent: Formula tool with IsEmpty() check, Data Cleansing tool
+    Trino Compatible: Yes
+
+    Arguments:
+        column: The column to clean
+        trim_first: Whether to trim whitespace before checking (default: true)
+
+    Example Usage:
+        select
+            {{ null_if_empty('customer_name') }} as customer_name,
+            {{ null_if_empty('email', trim_first=false) }} as email
+        from {{ ref('raw_customers') }}
+#}
+
+{% macro null_if_empty(column, trim_first=true) %}
+{% if trim_first %}
+nullif(trim({{ column }}), '')
+{% else %}
+nullif({{ column }}, '')
+{% endif %}
+{% endmacro %}
+
+
+{#
+    Macro: coalesce_empty
+    Description: Returns fallback value for NULL or empty strings.
+
+    Alteryx Equivalent: IIF(IsNull([field]) OR IsEmpty([field]), default, [field])
+
+    Arguments:
+        column: The column to check
+        fallback: Value to use if null or empty
+        trim_first: Whether to trim before checking (default: true)
+#}
+
+{% macro coalesce_empty(column, fallback, trim_first=true) %}
+coalesce({{ null_if_empty(column, trim_first) }}, {{ fallback }})
+{% endmacro %}
+
+
+{#
+    Macro: clean_string
+    Description: Comprehensive string cleaning - trims, converts empty to null, optionally normalizes case.
+
+    Alteryx Equivalent: Data Cleansing tool + Formula tool
+
+    Arguments:
+        column: The column to clean
+        null_empty: Convert empty to null (default: true)
+        case_style: 'upper', 'lower', 'proper', or none (default: none)
+        remove_leading_zeros: Remove leading zeros (default: false)
+        max_length: Truncate to max length (optional)
+#}
+
+{% macro clean_string(column, null_empty=true, case_style=none, remove_leading_zeros=false, max_length=none) %}
+{%- set result = 'trim(' ~ column ~ ')' -%}
+
+{%- if case_style == 'upper' -%}
+    {%- set result = 'upper(' ~ result ~ ')' -%}
+{%- elif case_style == 'lower' -%}
+    {%- set result = 'lower(' ~ result ~ ')' -%}
+{%- elif case_style == 'proper' -%}
+    {# Trino doesn't have PROPER/INITCAP by default, use regex #}
+    {%- set result = "regexp_replace(" ~ result ~ ", '(^|\\s)(\\w)', x -> upper(x))" -%}
+{%- endif -%}
+
+{%- if remove_leading_zeros -%}
+    {%- set result = "regexp_replace(" ~ result ~ ", '^0+', '')" -%}
+{%- endif -%}
+
+{%- if max_length -%}
+    {%- set result = 'substr(' ~ result ~ ', 1, ' ~ max_length ~ ')' -%}
+{%- endif -%}
+
+{%- if null_empty -%}
+nullif({{ result }}, '')
+{%- else -%}
+{{ result }}
+{%- endif -%}
+{% endmacro %}
+
+
+{#
+    Macro: is_null_or_empty
+    Description: Returns true if value is null, empty string, or whitespace-only.
+
+    Alteryx Equivalent: IsNull([field]) OR IsEmpty([field])
+
+    Arguments:
+        column: The column to check
+#}
+
+{% macro is_null_or_empty(column) %}
+({{ column }} is null or trim({{ column }}) = '')
+{% endmacro %}
+
+
+{#
+    Macro: clean_columns
+    Description: Applies string cleaning to multiple columns at once.
+
+    Arguments:
+        relation: The source relation
+        columns_to_clean: List of column names to clean (if null, cleans all varchar columns)
+        null_empty: Convert empty to null (default: true)
+        case_style: Case normalization (optional)
+#}
+
+{% macro clean_columns(relation, columns_to_clean=none, null_empty=true, case_style=none) %}
+
+select
+    {%- set all_columns = adapter.get_columns_in_relation(relation) %}
+    {%- for column in all_columns %}
+        {%- if columns_to_clean is none or column.name in columns_to_clean %}
+            {%- if column.is_string() %}
+    {{ clean_string(column.name, null_empty=null_empty, case_style=case_style) }} as {{ column.name }}
+            {%- else %}
+    {{ column.name }}
+            {%- endif %}
+        {%- else %}
+    {{ column.name }}
+        {%- endif %}
+        {%- if not loop.last %},{% endif %}
+    {%- endfor %}
+from {{ relation }}
+
+{% endmacro %}
+
+
+{#
+    Macro: standardize_nulls
+    Description: Converts various null representations to actual NULL.
+
+    Alteryx Equivalent: Data Cleansing tool (replace specific values)
+
+    Arguments:
+        column: The column to standardize
+        null_values: List of values to treat as null (default: common patterns)
+#}
+
+{% macro standardize_nulls(column, null_values=none) %}
+{%- set default_null_values = ['', 'NULL', 'null', 'N/A', 'n/a', 'NA', 'na', '#N/A', 'None', 'none', '-', '.'] -%}
+{%- set values_to_check = null_values if null_values else default_null_values -%}
+
+case
+    when trim({{ column }}) in (
+        {%- for val in values_to_check -%}
+        '{{ val }}'{% if not loop.last %}, {% endif %}
+        {%- endfor -%}
+    ) then null
+    else {{ column }}
+end
+{% endmacro %}

--- a/dbt_macros/pivot.sql
+++ b/dbt_macros/pivot.sql
@@ -1,0 +1,141 @@
+{#
+    Macro: pivot
+    Description: Pivots rows into columns using conditional aggregation.
+
+    Alteryx Equivalent: CrossTab tool
+    Trino Compatible: Yes
+
+    Arguments:
+        relation: The source relation
+        row_key: Column(s) that define the row identity (can be list)
+        pivot_column: Column whose values become new column headers
+        value_column: Column containing values to aggregate
+        agg_function: Aggregation function ('sum', 'count', 'max', 'min', 'avg') (default: 'sum')
+        pivot_values: List of values to pivot (if known ahead of time)
+        then_value: Value to use in CASE WHEN (default: value_column)
+        else_value: Value when condition not met (default: null)
+        prefix: Prefix for pivoted column names (default: '')
+        suffix: Suffix for pivoted column names (default: '')
+        quote_alias: Whether to quote column aliases (default: false)
+
+    Example Usage:
+        {{ pivot(
+            relation=ref('stg_sales'),
+            row_key='product_id',
+            pivot_column='region',
+            value_column='revenue',
+            agg_function='sum',
+            pivot_values=['North', 'South', 'East', 'West'],
+            prefix='revenue_'
+        ) }}
+
+    Input:
+        product_id | region | revenue
+        1          | North  | 100
+        1          | South  | 150
+
+    Output:
+        product_id | revenue_North | revenue_South | revenue_East | revenue_West
+        1          | 100           | 150           | null         | null
+#}
+
+{% macro pivot(relation, row_key, pivot_column, value_column, agg_function='sum', pivot_values=none, then_value=none, else_value='null', prefix='', suffix='', quote_alias=false) %}
+
+{%- set row_keys = row_key if row_key is iterable and row_key is not string else [row_key] -%}
+{%- set then_val = then_value if then_value else value_column -%}
+
+select
+    {{ row_keys | join(', ') }}
+    {%- for pv in pivot_values %},
+    {{ agg_function }}(case when {{ pivot_column }} = '{{ pv }}' then {{ then_val }} else {{ else_value }} end) as {% if quote_alias %}"{% endif %}{{ prefix }}{{ pv | replace(' ', '_') | replace('-', '_') }}{{ suffix }}{% if quote_alias %}"{% endif %}
+    {%- endfor %}
+from {{ relation }}
+group by {{ row_keys | join(', ') }}
+
+{% endmacro %}
+
+
+{#
+    Macro: unpivot
+    Description: Unpivots columns into rows (reverse of pivot/crosstab).
+
+    Alteryx Equivalent: Transpose tool
+    Trino Compatible: Yes (uses CROSS JOIN UNNEST with ARRAY of ROW)
+
+    Arguments:
+        relation: The source relation
+        key_columns: Columns to keep as identifiers (not unpivoted)
+        unpivot_columns: Columns to unpivot into rows
+        name_column: Name for the column containing original column names (default: 'attribute')
+        value_column: Name for the column containing values (default: 'value')
+
+    Example Usage:
+        {{ unpivot(
+            relation=ref('stg_metrics'),
+            key_columns=['customer_id', 'date'],
+            unpivot_columns=['metric_a', 'metric_b', 'metric_c'],
+            name_column='metric_name',
+            value_column='metric_value'
+        ) }}
+
+    Input:
+        customer_id | date       | metric_a | metric_b | metric_c
+        1           | 2024-01-01 | 10       | 20       | 30
+
+    Output:
+        customer_id | date       | metric_name | metric_value
+        1           | 2024-01-01 | metric_a    | 10
+        1           | 2024-01-01 | metric_b    | 20
+        1           | 2024-01-01 | metric_c    | 30
+#}
+
+{% macro unpivot(relation, key_columns, unpivot_columns, name_column='attribute', value_column='value') %}
+
+select
+    {{ key_columns | join(', ') }},
+    {{ name_column }},
+    {{ value_column }}
+from {{ relation }}
+cross join unnest(
+    array[
+        {%- for col in unpivot_columns %}
+        row('{{ col }}', cast({{ col }} as varchar)){% if not loop.last %},{% endif %}
+        {%- endfor %}
+    ]
+) as t({{ name_column }}, {{ value_column }})
+
+{% endmacro %}
+
+
+{#
+    Macro: dynamic_pivot
+    Description: Generates pivot SQL dynamically based on distinct values.
+    Note: This generates the SQL string - use with run_query for dynamic execution.
+
+    Arguments:
+        source_table: Source table name
+        row_key: Row identifier column(s)
+        pivot_column: Column to pivot on
+        value_column: Value column
+        agg_function: Aggregation function
+#}
+
+{% macro dynamic_pivot(source_table, row_key, pivot_column, value_column, agg_function='sum') %}
+
+{%- set pivot_query %}
+    select distinct {{ pivot_column }} from {{ source_table }} order by 1
+{%- endset -%}
+
+{%- set results = run_query(pivot_query) -%}
+{%- set pivot_values = results.columns[0].values() -%}
+
+{{ pivot(
+    relation=source_table,
+    row_key=row_key,
+    pivot_column=pivot_column,
+    value_column=value_column,
+    agg_function=agg_function,
+    pivot_values=pivot_values
+) }}
+
+{% endmacro %}

--- a/dbt_macros/running_total.sql
+++ b/dbt_macros/running_total.sql
@@ -1,0 +1,109 @@
+{#
+    Macro: running_total
+    Description: Calculates running/cumulative totals using window functions.
+
+    Alteryx Equivalent: Multi-Row Formula, Running Total tool
+    Trino Compatible: Yes
+
+    Arguments:
+        relation: The source relation
+        value_column: Column to sum cumulatively
+        partition_by: List of columns to partition by (optional, for grouped running totals)
+        order_by: List of columns to order by (determines cumulative order)
+        alias: Name for the running total column (default: 'running_total')
+        include_current: Whether to include current row in sum (default: true)
+
+    Example Usage:
+        {{ running_total(
+            relation=ref('stg_sales'),
+            value_column='amount',
+            partition_by=['customer_id'],
+            order_by=['transaction_date'],
+            alias='cumulative_sales'
+        ) }}
+#}
+
+{% macro running_total(relation, value_column, partition_by=none, order_by=none, alias='running_total', include_current=true) %}
+
+select
+    *,
+    sum({{ value_column }}) over (
+        {% if partition_by %}
+        partition by {{ partition_by | join(', ') }}
+        {% endif %}
+        {% if order_by %}
+        order by {{ order_by | join(', ') }}
+        {% endif %}
+        rows between unbounded preceding and {% if include_current %}current row{% else %}1 preceding{% endif %}
+    ) as {{ alias }}
+from {{ relation }}
+
+{% endmacro %}
+
+
+{#
+    Macro: running_count
+    Description: Calculates running count of rows.
+
+    Alteryx Equivalent: RecordID tool, Running Total (Count mode)
+
+    Arguments:
+        relation: The source relation
+        partition_by: List of columns to partition by (optional)
+        order_by: List of columns to order by
+        alias: Name for the running count column (default: 'row_num')
+#}
+
+{% macro running_count(relation, partition_by=none, order_by=none, alias='row_num') %}
+
+select
+    *,
+    count(*) over (
+        {% if partition_by %}
+        partition by {{ partition_by | join(', ') }}
+        {% endif %}
+        {% if order_by %}
+        order by {{ order_by | join(', ') }}
+        {% endif %}
+        rows between unbounded preceding and current row
+    ) as {{ alias }}
+from {{ relation }}
+
+{% endmacro %}
+
+
+{#
+    Macro: running_average
+    Description: Calculates running/moving average.
+
+    Alteryx Equivalent: Multi-Row Formula with average calculation
+
+    Arguments:
+        relation: The source relation
+        value_column: Column to average
+        partition_by: Partition columns (optional)
+        order_by: Order columns
+        alias: Output column name
+        window_size: Number of rows for moving average (null = all preceding rows)
+#}
+
+{% macro running_average(relation, value_column, partition_by=none, order_by=none, alias='running_avg', window_size=none) %}
+
+select
+    *,
+    avg({{ value_column }}) over (
+        {% if partition_by %}
+        partition by {{ partition_by | join(', ') }}
+        {% endif %}
+        {% if order_by %}
+        order by {{ order_by | join(', ') }}
+        {% endif %}
+        {% if window_size %}
+        rows between {{ window_size - 1 }} preceding and current row
+        {% else %}
+        rows between unbounded preceding and current row
+        {% endif %}
+    ) as {{ alias }}
+from {{ relation }}
+
+{% endmacro %}

--- a/dbt_macros/safe_cast.sql
+++ b/dbt_macros/safe_cast.sql
@@ -1,0 +1,154 @@
+{#
+    Macro: safe_cast
+    Description: Safely casts a column to a target type with fallback value on failure.
+
+    Alteryx Equivalent: Formula tool with error handling, ToNumber(), ToString(), etc.
+    Trino Compatible: Yes (uses TRY_CAST)
+
+    Arguments:
+        column: The column or expression to cast
+        target_type: The target data type (varchar, integer, double, date, timestamp, etc.)
+        fallback: Value to use if cast fails (default: null)
+
+    Example Usage:
+        {{ safe_cast('order_amount', 'double', 0.0) }}
+        {{ safe_cast('birth_date', 'date') }}
+#}
+
+{% macro safe_cast(column, target_type, fallback=none) %}
+{% if fallback is not none %}
+coalesce(try_cast({{ column }} as {{ target_type }}), {{ fallback }})
+{% else %}
+try_cast({{ column }} as {{ target_type }})
+{% endif %}
+{% endmacro %}
+
+
+{#
+    Macro: safe_cast_columns
+    Description: Applies safe casting to multiple columns at once.
+
+    Arguments:
+        relation: The source relation
+        column_types: Dictionary of column_name: target_type pairs
+        fallback_map: Optional dictionary of column_name: fallback_value pairs
+
+    Example Usage:
+        {{ safe_cast_columns(
+            relation=ref('raw_data'),
+            column_types={'amount': 'double', 'quantity': 'integer', 'order_date': 'date'},
+            fallback_map={'amount': 0.0, 'quantity': 0}
+        ) }}
+#}
+
+{% macro safe_cast_columns(relation, column_types, fallback_map=none) %}
+
+select
+    {%- set all_columns = adapter.get_columns_in_relation(relation) %}
+    {%- for column in all_columns %}
+        {%- if column.name in column_types %}
+            {%- set fallback = fallback_map[column.name] if fallback_map and column.name in fallback_map else none %}
+    {{ safe_cast(column.name, column_types[column.name], fallback) }} as {{ column.name }}
+        {%- else %}
+    {{ column.name }}
+        {%- endif %}
+        {%- if not loop.last %},{% endif %}
+    {%- endfor %}
+from {{ relation }}
+
+{% endmacro %}
+
+
+{#
+    Macro: to_varchar
+    Description: Safely converts any column to varchar/string.
+
+    Alteryx Equivalent: ToString() function
+#}
+
+{% macro to_varchar(column, fallback="''") %}
+coalesce(cast({{ column }} as varchar), {{ fallback }})
+{% endmacro %}
+
+
+{#
+    Macro: to_integer
+    Description: Safely converts column to integer with fallback.
+
+    Alteryx Equivalent: ToNumber() function with integer result
+#}
+
+{% macro to_integer(column, fallback=0) %}
+coalesce(try_cast({{ column }} as integer), {{ fallback }})
+{% endmacro %}
+
+
+{#
+    Macro: to_double
+    Description: Safely converts column to double/decimal with fallback.
+
+    Alteryx Equivalent: ToNumber() function
+#}
+
+{% macro to_double(column, fallback=0.0) %}
+coalesce(try_cast({{ column }} as double), {{ fallback }})
+{% endmacro %}
+
+
+{#
+    Macro: to_date
+    Description: Safely parses string to date with optional format.
+
+    Alteryx Equivalent: DateTimeParse() function
+    Trino: Uses date_parse for formatted strings
+
+    Arguments:
+        column: The column to convert
+        format: Date format string (Trino format, e.g., '%Y-%m-%d')
+        fallback: Fallback date value (optional)
+#}
+
+{% macro to_date(column, format=none, fallback=none) %}
+{% if format %}
+    {% if fallback is not none %}
+coalesce(try(date(date_parse({{ column }}, '{{ format }}'))), {{ fallback }})
+    {% else %}
+try(date(date_parse({{ column }}, '{{ format }}')))
+    {% endif %}
+{% else %}
+    {% if fallback is not none %}
+coalesce(try_cast({{ column }} as date), {{ fallback }})
+    {% else %}
+try_cast({{ column }} as date)
+    {% endif %}
+{% endif %}
+{% endmacro %}
+
+
+{#
+    Macro: to_timestamp
+    Description: Safely parses string to timestamp with optional format.
+
+    Alteryx Equivalent: DateTimeParse() function
+
+    Arguments:
+        column: The column to convert
+        format: Timestamp format string (Trino format)
+        fallback: Fallback timestamp value (optional)
+#}
+
+{% macro to_timestamp(column, format=none, fallback=none) %}
+{% if format %}
+    {% if fallback is not none %}
+coalesce(try(date_parse({{ column }}, '{{ format }}')), {{ fallback }})
+    {% else %}
+try(date_parse({{ column }}, '{{ format }}'))
+    {% endif %}
+{% else %}
+    {% if fallback is not none %}
+coalesce(try_cast({{ column }} as timestamp), {{ fallback }})
+    {% else %}
+try_cast({{ column }} as timestamp)
+    {% endif %}
+{% endif %}
+{% endmacro %}

--- a/dbt_macros/split_unnest.sql
+++ b/dbt_macros/split_unnest.sql
@@ -1,0 +1,130 @@
+{#
+    Macro: split_unnest
+    Description: Splits a delimited column and unnests into multiple rows.
+
+    Alteryx Equivalent: Text to Columns tool, Transpose tool
+    Trino Compatible: Yes (uses CROSS JOIN UNNEST with SPLIT)
+
+    Arguments:
+        relation: The source relation
+        column: The column containing delimited values
+        delimiter: The delimiter string (default: ',')
+        output_alias: Name for the unnested value column (default: 'value')
+        trim_values: Whether to trim whitespace from split values (default: true)
+        filter_empty: Whether to filter out empty values (default: true)
+
+    Example Usage:
+        {{ split_unnest(
+            relation=ref('stg_products'),
+            column='tags',
+            delimiter=',',
+            output_alias='tag'
+        ) }}
+
+    Input:  id=1, tags='red,blue,green'
+    Output: id=1, tag='red'
+            id=1, tag='blue'
+            id=1, tag='green'
+#}
+
+{% macro split_unnest(relation, column, delimiter=',', output_alias='value', trim_values=true, filter_empty=true) %}
+
+select
+    {%- set columns = adapter.get_columns_in_relation(relation) %}
+    {%- for col in columns %}
+        {%- if col.name != column %}
+    t.{{ col.name }},
+        {%- endif %}
+    {%- endfor %}
+    {% if trim_values %}
+    trim({{ output_alias }}) as {{ output_alias }}
+    {% else %}
+    {{ output_alias }}
+    {% endif %}
+from {{ relation }} t
+cross join unnest(split({{ column }}, '{{ delimiter }}')) as x({{ output_alias }})
+{% if filter_empty %}
+where {% if trim_values %}trim({{ output_alias }}){% else %}{{ output_alias }}{% endif %} <> ''
+{% endif %}
+
+{% endmacro %}
+
+
+{#
+    Macro: split_to_columns
+    Description: Splits a delimited column into multiple fixed columns.
+
+    Alteryx Equivalent: Text to Columns tool (split to columns mode)
+
+    Arguments:
+        relation: The source relation
+        column: The column containing delimited values
+        delimiter: The delimiter string
+        num_columns: Number of output columns to create
+        column_prefix: Prefix for output column names (default: 'part')
+
+    Example Usage:
+        {{ split_to_columns(
+            relation=ref('stg_addresses'),
+            column='full_name',
+            delimiter=' ',
+            num_columns=3,
+            column_prefix='name'
+        ) }}
+
+    Input:  full_name='John Adam Smith'
+    Output: name_1='John', name_2='Adam', name_3='Smith'
+#}
+
+{% macro split_to_columns(relation, column, delimiter, num_columns, column_prefix='part') %}
+
+with split_array as (
+    select
+        *,
+        split({{ column }}, '{{ delimiter }}') as _parts
+    from {{ relation }}
+)
+
+select
+    {%- set columns = adapter.get_columns_in_relation(relation) %}
+    {%- for col in columns %}
+        {%- if col.name != column %}
+    {{ col.name }},
+        {%- endif %}
+    {%- endfor %}
+    {%- for i in range(1, num_columns + 1) %}
+    element_at(_parts, {{ i }}) as {{ column_prefix }}_{{ i }}{% if not loop.last %},{% endif %}
+    {%- endfor %}
+from split_array
+
+{% endmacro %}
+
+
+{#
+    Macro: array_agg_to_string
+    Description: Aggregates multiple rows into a delimited string (reverse of split_unnest).
+
+    Alteryx Equivalent: Summarize tool with Concatenate action
+
+    Arguments:
+        relation: The source relation
+        group_by: List of columns to group by
+        value_column: Column to aggregate
+        delimiter: Delimiter for concatenation (default: ',')
+        output_alias: Name for the aggregated column
+        distinct_values: Whether to only include distinct values (default: false)
+        order_by: Column to order values before concatenation (optional)
+#}
+
+{% macro array_agg_to_string(relation, group_by, value_column, delimiter=',', output_alias='concatenated', distinct_values=false, order_by=none) %}
+
+select
+    {{ group_by | join(', ') }},
+    array_join(
+        array_agg({% if distinct_values %}distinct {% endif %}{{ value_column }}{% if order_by %} order by {{ order_by }}{% endif %}),
+        '{{ delimiter }}'
+    ) as {{ output_alias }}
+from {{ relation }}
+group by {{ group_by | join(', ') }}
+
+{% endmacro %}

--- a/dbt_macros/string_normalize.sql
+++ b/dbt_macros/string_normalize.sql
@@ -1,0 +1,260 @@
+{#
+    Macro: string_normalize
+    Description: Normalizes strings for consistent comparison and matching.
+
+    Alteryx Equivalent: Data Cleansing tool + Formula tool
+    Trino Compatible: Yes
+
+    Arguments:
+        column: The column to normalize
+        options: Dict with normalization options:
+            - trim: Remove leading/trailing whitespace (default: true)
+            - case: 'upper', 'lower', or none (default: 'lower')
+            - remove_accents: Replace accented chars (default: false)
+            - remove_punctuation: Remove punctuation (default: false)
+            - remove_extra_spaces: Collapse multiple spaces to one (default: true)
+            - alphanumeric_only: Keep only letters and numbers (default: false)
+
+    Example Usage:
+        select
+            {{ string_normalize('company_name', {'case': 'upper', 'remove_punctuation': true}) }} as normalized_name
+        from {{ ref('stg_companies') }}
+#}
+
+{% macro string_normalize(column, options={}) %}
+{%- set trim = options.get('trim', true) -%}
+{%- set case_style = options.get('case', 'lower') -%}
+{%- set remove_accents = options.get('remove_accents', false) -%}
+{%- set remove_punctuation = options.get('remove_punctuation', false) -%}
+{%- set remove_extra_spaces = options.get('remove_extra_spaces', true) -%}
+{%- set alphanumeric_only = options.get('alphanumeric_only', false) -%}
+
+{%- set result = column -%}
+
+{# Step 1: Trim whitespace #}
+{%- if trim -%}
+    {%- set result = 'trim(' ~ result ~ ')' -%}
+{%- endif -%}
+
+{# Step 2: Case normalization #}
+{%- if case_style == 'upper' -%}
+    {%- set result = 'upper(' ~ result ~ ')' -%}
+{%- elif case_style == 'lower' -%}
+    {%- set result = 'lower(' ~ result ~ ')' -%}
+{%- endif -%}
+
+{# Step 3: Remove accents (common replacements) #}
+{%- if remove_accents -%}
+    {%- set result = "translate(" ~ result ~ ", 'àáâãäåèéêëìíîïòóôõöùúûüýÿñçÀÁÂÃÄÅÈÉÊËÌÍÎÏÒÓÔÕÖÙÚÛÜÝÑÇ', 'aaaaaaeeeeiiiiooooouuuuyyncAAAAAAEEEEIIIIOOOOOUUUUYNC')" -%}
+{%- endif -%}
+
+{# Step 4: Remove punctuation #}
+{%- if remove_punctuation -%}
+    {%- set result = "regexp_replace(" ~ result ~ ", '[^a-zA-Z0-9\\s]', '')" -%}
+{%- endif -%}
+
+{# Step 5: Alphanumeric only (more aggressive than remove_punctuation) #}
+{%- if alphanumeric_only -%}
+    {%- set result = "regexp_replace(" ~ result ~ ", '[^a-zA-Z0-9]', '')" -%}
+{%- endif -%}
+
+{# Step 6: Remove extra spaces (collapse multiple to single) #}
+{%- if remove_extra_spaces and not alphanumeric_only -%}
+    {%- set result = "regexp_replace(" ~ result ~ ", '\\s+', ' ')" -%}
+{%- endif -%}
+
+{{ result }}
+{% endmacro %}
+
+
+{#
+    Macro: extract_numbers
+    Description: Extracts all numeric characters from a string.
+
+    Alteryx Equivalent: REGEX_Replace([field], '[^0-9]', '')
+
+    Arguments:
+        column: The column to extract numbers from
+#}
+
+{% macro extract_numbers(column) %}
+regexp_replace({{ column }}, '[^0-9]', '')
+{% endmacro %}
+
+
+{#
+    Macro: extract_letters
+    Description: Extracts all letter characters from a string.
+
+    Alteryx Equivalent: REGEX_Replace([field], '[^a-zA-Z]', '')
+
+    Arguments:
+        column: The column to extract letters from
+#}
+
+{% macro extract_letters(column) %}
+regexp_replace({{ column }}, '[^a-zA-Z]', '')
+{% endmacro %}
+
+
+{#
+    Macro: phone_normalize
+    Description: Normalizes phone numbers to digits only.
+
+    Alteryx Equivalent: REGEX_Replace for phone cleaning
+
+    Arguments:
+        column: Phone number column
+        include_country_code: Keep country code (default: true)
+        default_country_code: Country code to prepend if missing (optional)
+#}
+
+{% macro phone_normalize(column, include_country_code=true, default_country_code=none) %}
+{%- set cleaned = "regexp_replace(" ~ column ~ ", '[^0-9]', '')" -%}
+{% if not include_country_code %}
+{# Remove leading 1 for US numbers if they're 11 digits #}
+case
+    when length({{ cleaned }}) = 11 and substr({{ cleaned }}, 1, 1) = '1'
+    then substr({{ cleaned }}, 2)
+    else {{ cleaned }}
+end
+{% elif default_country_code %}
+case
+    when length({{ cleaned }}) = 10
+    then '{{ default_country_code }}' || {{ cleaned }}
+    else {{ cleaned }}
+end
+{% else %}
+{{ cleaned }}
+{% endif %}
+{% endmacro %}
+
+
+{#
+    Macro: email_normalize
+    Description: Normalizes email addresses (lowercase, trim).
+
+    Alteryx Equivalent: Formula with LowerCase(Trim([email]))
+
+    Arguments:
+        column: Email column
+        extract_domain: If true, returns only the domain (default: false)
+        extract_local: If true, returns only the local part (default: false)
+#}
+
+{% macro email_normalize(column, extract_domain=false, extract_local=false) %}
+{% if extract_domain %}
+lower(trim(regexp_extract({{ column }}, '@(.+)$', 1)))
+{% elif extract_local %}
+lower(trim(regexp_extract({{ column }}, '^([^@]+)@', 1)))
+{% else %}
+lower(trim({{ column }}))
+{% endif %}
+{% endmacro %}
+
+
+{#
+    Macro: proper_case
+    Description: Converts string to proper/title case (capitalize first letter of each word).
+
+    Alteryx Equivalent: TitleCase() function
+    Trino: Uses regexp_replace with callback
+
+    Arguments:
+        column: The column to convert
+#}
+
+{% macro proper_case(column) %}
+regexp_replace(
+    lower({{ column }}),
+    '(^|[^a-zA-Z])([a-z])',
+    x -> concat(element_at(regexp_extract_all(x, '(^|[^a-zA-Z])'), 1), upper(element_at(regexp_extract_all(x, '([a-z])'), 1)))
+)
+{% endmacro %}
+
+
+{#
+    Macro: pad_left
+    Description: Left-pads a string to a specified length.
+
+    Alteryx Equivalent: PadLeft([field], length, 'char')
+
+    Arguments:
+        column: The column to pad
+        length: Target length
+        pad_char: Character to pad with (default: '0')
+#}
+
+{% macro pad_left(column, length, pad_char='0') %}
+lpad(cast({{ column }} as varchar), {{ length }}, '{{ pad_char }}')
+{% endmacro %}
+
+
+{#
+    Macro: pad_right
+    Description: Right-pads a string to a specified length.
+
+    Alteryx Equivalent: PadRight([field], length, 'char')
+
+    Arguments:
+        column: The column to pad
+        length: Target length
+        pad_char: Character to pad with (default: ' ')
+#}
+
+{% macro pad_right(column, length, pad_char=' ') %}
+rpad(cast({{ column }} as varchar), {{ length }}, '{{ pad_char }}')
+{% endmacro %}
+
+
+{#
+    Macro: contains
+    Description: Returns true if string contains substring.
+
+    Alteryx Equivalent: Contains([field], 'substring')
+
+    Arguments:
+        column: The column to search in
+        substring: The substring to search for
+        case_sensitive: Whether search is case-sensitive (default: true)
+#}
+
+{% macro contains(column, substring, case_sensitive=true) %}
+{% if case_sensitive %}
+strpos({{ column }}, '{{ substring }}') > 0
+{% else %}
+strpos(lower({{ column }}), lower('{{ substring }}')) > 0
+{% endif %}
+{% endmacro %}
+
+
+{#
+    Macro: starts_with
+    Description: Returns true if string starts with prefix.
+
+    Alteryx Equivalent: StartsWith([field], 'prefix')
+#}
+
+{% macro starts_with(column, prefix, case_sensitive=true) %}
+{% if case_sensitive %}
+substr({{ column }}, 1, {{ prefix | length }}) = '{{ prefix }}'
+{% else %}
+lower(substr({{ column }}, 1, {{ prefix | length }})) = lower('{{ prefix }}')
+{% endif %}
+{% endmacro %}
+
+
+{#
+    Macro: ends_with
+    Description: Returns true if string ends with suffix.
+
+    Alteryx Equivalent: EndsWith([field], 'suffix')
+#}
+
+{% macro ends_with(column, suffix, case_sensitive=true) %}
+{% if case_sensitive %}
+substr({{ column }}, -{{ suffix | length }}) = '{{ suffix }}'
+{% else %}
+lower(substr({{ column }}, -{{ suffix | length }})) = lower('{{ suffix }}')
+{% endif %}
+{% endmacro %}

--- a/dbt_macros/window_rank.sql
+++ b/dbt_macros/window_rank.sql
@@ -1,0 +1,130 @@
+{#
+    Macro: window_rank
+    Description: Adds ranking columns using various ranking functions.
+
+    Alteryx Equivalent: RecordID tool, Multi-Row Formula with ranking
+    Trino Compatible: Yes
+
+    Arguments:
+        relation: The source relation
+        partition_by: List of columns to partition by (optional)
+        order_by: List of columns to order by
+        rank_type: 'row_number', 'rank', 'dense_rank', 'percent_rank', 'ntile'
+        alias: Name for the rank column (default: 'rank')
+        order_direction: 'asc' or 'desc' (default: 'asc')
+        ntile_buckets: Number of buckets for ntile (only used when rank_type='ntile')
+
+    Example Usage:
+        {{ window_rank(
+            relation=ref('stg_sales'),
+            partition_by=['region'],
+            order_by=['revenue'],
+            rank_type='row_number',
+            alias='sales_rank',
+            order_direction='desc'
+        ) }}
+#}
+
+{% macro window_rank(relation, order_by, partition_by=none, rank_type='row_number', alias='rank', order_direction='asc', ntile_buckets=4) %}
+
+select
+    *,
+    {% if rank_type == 'ntile' %}
+    ntile({{ ntile_buckets }})
+    {% else %}
+    {{ rank_type }}()
+    {% endif %}
+    over (
+        {% if partition_by %}
+        partition by {{ partition_by | join(', ') }}
+        {% endif %}
+        order by {{ order_by | join(' ' ~ order_direction ~ ', ') }} {{ order_direction }}
+    ) as {{ alias }}
+from {{ relation }}
+
+{% endmacro %}
+
+
+{#
+    Macro: top_n_per_group
+    Description: Returns top N rows per group based on ordering.
+
+    Alteryx Equivalent: Sample tool (First N per group), or Sort + RecordID + Filter
+
+    Arguments:
+        relation: The source relation
+        partition_by: Columns defining groups
+        order_by: Columns to order by within groups
+        n: Number of rows to keep per group (default: 1)
+        order_direction: 'asc' or 'desc'
+
+    Example Usage:
+        {{ top_n_per_group(
+            relation=ref('stg_orders'),
+            partition_by=['customer_id'],
+            order_by=['order_date'],
+            n=3,
+            order_direction='desc'
+        ) }}
+#}
+
+{% macro top_n_per_group(relation, partition_by, order_by, n=1, order_direction='desc') %}
+
+with ranked as (
+    select
+        *,
+        row_number() over (
+            partition by {{ partition_by | join(', ') }}
+            order by {{ order_by | join(' ' ~ order_direction ~ ', ') }} {{ order_direction }}
+        ) as _row_rank
+    from {{ relation }}
+)
+
+select
+    {%- set columns = adapter.get_columns_in_relation(relation) %}
+    {%- for column in columns %}
+    {{ column.name }}{% if not loop.last %},{% endif %}
+    {%- endfor %}
+from ranked
+where _row_rank <= {{ n }}
+
+{% endmacro %}
+
+
+{#
+    Macro: lag_lead
+    Description: Adds previous/next row values using LAG/LEAD window functions.
+
+    Alteryx Equivalent: Multi-Row Formula
+
+    Arguments:
+        relation: The source relation
+        value_column: Column to get lag/lead values from
+        partition_by: Partition columns (optional)
+        order_by: Order columns
+        lag_offset: Number of rows to look back (default: 1)
+        lead_offset: Number of rows to look forward (default: 1)
+        lag_alias: Name for lag column
+        lead_alias: Name for lead column
+        default_value: Value when lag/lead is null (optional)
+#}
+
+{% macro lag_lead(relation, value_column, order_by, partition_by=none, lag_offset=1, lead_offset=1, lag_alias='prev_value', lead_alias='next_value', default_value=none) %}
+
+select
+    *,
+    lag({{ value_column }}, {{ lag_offset }}{% if default_value is not none %}, {{ default_value }}{% endif %}) over (
+        {% if partition_by %}
+        partition by {{ partition_by | join(', ') }}
+        {% endif %}
+        order by {{ order_by | join(', ') }}
+    ) as {{ lag_alias }},
+    lead({{ value_column }}, {{ lead_offset }}{% if default_value is not none %}, {{ default_value }}{% endif %}) over (
+        {% if partition_by %}
+        partition by {{ partition_by | join(', ') }}
+        {% endif %}
+        order by {{ order_by | join(', ') }}
+    ) as {{ lead_alias }}
+from {{ relation }}
+
+{% endmacro %}


### PR DESCRIPTION
Created 10 Trino/Starburst-compatible DBT macros that implement common
Alteryx transformation patterns:

1. deduplicate.sql - ROW_NUMBER deduplication (Alteryx: Unique tool)
2. running_total.sql - Window SUM for cumulative totals (Multi-Row Formula)
3. window_rank.sql - RANK/DENSE_RANK/ROW_NUMBER (RecordID tool)
4. safe_cast.sql - TRY_CAST with fallback values (Formula tool)
5. split_unnest.sql - CROSS JOIN UNNEST for text splitting (Text to Columns)
6. generate_surrogate_key.sql - MD5/xxhash64 key generation
7. pivot.sql - CASE WHEN aggregation for CrossTab
8. null_if_empty.sql - String cleaning and null standardization
9. date_spine.sql - Date sequence generation (Generate Rows)
10. string_normalize.sql - Text normalization functions

Updated dbt_generator.py to automatically copy these macros into
generated DBT projects under macros/migration/ directory.

https://claude.ai/code/session_01FmQunrRPtWSoiU6UMdL2sU