### PR TITLE
Add comprehensive DBT macros for all Alteryx preparation functions

### DIFF
--- a/dbt_macros/aggregation.sql
+++ b/dbt_macros/aggregation.sql
@@ -1,0 +1,409 @@
+{#
+    =============================================================================
+    Aggregation Macros
+    Alteryx Equivalent: Summarize tool
+    Trino Compatible: Yes
+    =============================================================================
+
+    These macros provide comprehensive aggregation functionality matching
+    all Alteryx Summarize tool capabilities.
+#}
+
+{#
+    Macro: summarize
+    Description: General-purpose aggregation matching Alteryx Summarize tool.
+
+    Alteryx Equivalent: Summarize tool
+
+    Arguments:
+        relation: Source relation
+        group_by: List of columns to group by
+        aggregations: List of [column, agg_function, alias] tuples
+                     Supported functions: sum, count, count_distinct, min, max, avg,
+                     first, last, concat, stddev, variance, median
+
+    Example Usage:
+        {{ summarize(
+            relation=ref('stg_orders'),
+            group_by=['customer_id', 'region'],
+            aggregations=[
+                ['order_amount', 'sum', 'total_revenue'],
+                ['order_id', 'count', 'order_count'],
+                ['order_date', 'min', 'first_order'],
+                ['order_date', 'max', 'last_order'],
+                ['order_amount', 'avg', 'avg_order_value']
+            ]
+        ) }}
+#}
+
+{% macro summarize(relation, group_by, aggregations) %}
+
+select
+    {{ group_by | join(',\n    ') }},
+    {%- for agg in aggregations %}
+        {%- set col = agg[0] %}
+        {%- set func = agg[1] | lower %}
+        {%- set alias = agg[2] %}
+        {%- if func == 'sum' %}
+    sum({{ col }}) as {{ alias }}
+        {%- elif func == 'count' %}
+    count({{ col }}) as {{ alias }}
+        {%- elif func == 'count_distinct' %}
+    count(distinct {{ col }}) as {{ alias }}
+        {%- elif func == 'count_null' %}
+    sum(case when {{ col }} is null then 1 else 0 end) as {{ alias }}
+        {%- elif func == 'count_non_null' %}
+    count({{ col }}) as {{ alias }}
+        {%- elif func == 'min' %}
+    min({{ col }}) as {{ alias }}
+        {%- elif func == 'max' %}
+    max({{ col }}) as {{ alias }}
+        {%- elif func == 'avg' or func == 'average' %}
+    avg({{ col }}) as {{ alias }}
+        {%- elif func == 'first' %}
+    min_by({{ col }}, row_number() over ()) as {{ alias }}
+        {%- elif func == 'last' %}
+    max_by({{ col }}, row_number() over ()) as {{ alias }}
+        {%- elif func == 'concat' %}
+    array_join(array_agg({{ col }}), ',') as {{ alias }}
+        {%- elif func == 'concat_distinct' %}
+    array_join(array_agg(distinct {{ col }}), ',') as {{ alias }}
+        {%- elif func == 'stddev' %}
+    stddev({{ col }}) as {{ alias }}
+        {%- elif func == 'stddev_pop' %}
+    stddev_pop({{ col }}) as {{ alias }}
+        {%- elif func == 'variance' %}
+    variance({{ col }}) as {{ alias }}
+        {%- elif func == 'variance_pop' %}
+    var_pop({{ col }}) as {{ alias }}
+        {%- elif func == 'median' %}
+    approx_percentile({{ col }}, 0.5) as {{ alias }}
+        {%- else %}
+    {{ func }}({{ col }}) as {{ alias }}
+        {%- endif %}
+        {%- if not loop.last %},{% endif %}
+    {%- endfor %}
+from {{ relation }}
+group by {{ group_by | join(', ') }}
+
+{% endmacro %}
+
+
+{#
+    Macro: count_records
+    Description: Simple record count.
+
+    Alteryx Equivalent: Count Records tool, Summarize (Count)
+
+    Arguments:
+        relation: Source relation
+        group_by: Optional grouping columns
+        alias: Name for count column
+
+    Example Usage:
+        {{ count_records(ref('stg_orders'), group_by=['status']) }}
+#}
+
+{% macro count_records(relation, group_by=none, alias='record_count') %}
+
+select
+    {%- if group_by %}
+    {{ group_by | join(', ') }},
+    {%- endif %}
+    count(*) as {{ alias }}
+from {{ relation }}
+{%- if group_by %}
+group by {{ group_by | join(', ') }}
+{%- endif %}
+
+{% endmacro %}
+
+
+{#
+    Macro: sum_column
+    Description: Sums a column with optional grouping.
+
+    Alteryx Equivalent: Summarize (Sum)
+
+    Arguments:
+        relation: Source relation
+        column: Column to sum
+        group_by: Optional grouping columns
+        alias: Name for sum column
+
+    Example Usage:
+        {{ sum_column(ref('stg_sales'), 'revenue', group_by=['region']) }}
+#}
+
+{% macro sum_column(relation, column, group_by=none, alias=none) %}
+
+{%- set result_alias = alias if alias else column ~ '_sum' -%}
+
+select
+    {%- if group_by %}
+    {{ group_by | join(', ') }},
+    {%- endif %}
+    sum({{ column }}) as {{ result_alias }}
+from {{ relation }}
+{%- if group_by %}
+group by {{ group_by | join(', ') }}
+{%- endif %}
+
+{% endmacro %}
+
+
+{#
+    Macro: aggregate_all
+    Description: Applies multiple aggregations to all numeric columns.
+
+    Alteryx Equivalent: Summarize with multiple functions on all fields
+
+    Arguments:
+        relation: Source relation
+        group_by: Grouping columns
+        agg_functions: List of aggregation functions to apply
+
+    Example Usage:
+        {{ aggregate_all(ref('stg_metrics'), ['date'], ['sum', 'avg', 'min', 'max']) }}
+#}
+
+{% macro aggregate_all(relation, group_by, agg_functions=['sum', 'avg', 'min', 'max']) %}
+
+select
+    {{ group_by | join(', ') }}
+    {%- set all_columns = adapter.get_columns_in_relation(relation) %}
+    {%- set group_lower = group_by | map('lower') | list %}
+    {%- for col in all_columns %}
+        {%- if col.name|lower not in group_lower and col.is_numeric() %}
+            {%- for func in agg_functions %},
+    {{ func }}({{ col.name }}) as {{ col.name }}_{{ func }}
+            {%- endfor %}
+        {%- endif %}
+    {%- endfor %}
+from {{ relation }}
+group by {{ group_by | join(', ') }}
+
+{% endmacro %}
+
+
+{#
+    Macro: group_concat
+    Description: Concatenates values within a group.
+
+    Alteryx Equivalent: Summarize (Concat)
+
+    Arguments:
+        relation: Source relation
+        group_by: Grouping columns
+        concat_column: Column to concatenate
+        delimiter: Separator between values
+        alias: Name for concatenated column
+        distinct_values: Only include distinct values
+        order_by: Optional ordering within group
+
+    Example Usage:
+        {{ group_concat(
+            relation=ref('stg_tags'),
+            group_by=['product_id'],
+            concat_column='tag_name',
+            delimiter=', ',
+            alias='all_tags',
+            distinct_values=true
+        ) }}
+#}
+
+{% macro group_concat(relation, group_by, concat_column, delimiter=',', alias='concatenated', distinct_values=false, order_by=none) %}
+
+select
+    {{ group_by | join(', ') }},
+    array_join(
+        array_agg({% if distinct_values %}distinct {% endif %}{{ concat_column }}{% if order_by %} order by {{ order_by | join(', ') }}{% endif %}),
+        '{{ delimiter }}'
+    ) as {{ alias }}
+from {{ relation }}
+group by {{ group_by | join(', ') }}
+
+{% endmacro %}
+
+
+{#
+    Macro: first_last_value
+    Description: Gets first and/or last value within a group.
+
+    Alteryx Equivalent: Summarize (First/Last)
+
+    Arguments:
+        relation: Source relation
+        group_by: Grouping columns
+        value_column: Column to get first/last from
+        order_by: Column(s) determining order
+        get_first: Include first value (default: true)
+        get_last: Include last value (default: true)
+
+    Example Usage:
+        {{ first_last_value(
+            relation=ref('stg_transactions'),
+            group_by=['account_id'],
+            value_column='balance',
+            order_by=['transaction_date']
+        ) }}
+#}
+
+{% macro first_last_value(relation, group_by, value_column, order_by, get_first=true, get_last=true) %}
+
+select
+    {{ group_by | join(', ') }}
+    {%- if get_first %},
+    min_by({{ value_column }}, {{ order_by | join(', ') }}) as first_{{ value_column }}
+    {%- endif %}
+    {%- if get_last %},
+    max_by({{ value_column }}, {{ order_by | join(', ') }}) as last_{{ value_column }}
+    {%- endif %}
+from {{ relation }}
+group by {{ group_by | join(', ') }}
+
+{% endmacro %}
+
+
+{#
+    Macro: percentile_agg
+    Description: Calculates percentile values within groups.
+
+    Alteryx Equivalent: Summarize (Percentile)
+
+    Arguments:
+        relation: Source relation
+        group_by: Grouping columns
+        value_column: Column to calculate percentile on
+        percentiles: List of percentile values (0-1)
+
+    Example Usage:
+        {{ percentile_agg(
+            relation=ref('stg_orders'),
+            group_by=['region'],
+            value_column='order_amount',
+            percentiles=[0.25, 0.5, 0.75, 0.9, 0.99]
+        ) }}
+#}
+
+{% macro percentile_agg(relation, group_by, value_column, percentiles=[0.5]) %}
+
+select
+    {{ group_by | join(', ') }}
+    {%- for p in percentiles %},
+    approx_percentile({{ value_column }}, {{ p }}) as {{ value_column }}_p{{ (p * 100) | int }}
+    {%- endfor %}
+from {{ relation }}
+group by {{ group_by | join(', ') }}
+
+{% endmacro %}
+
+
+{#
+    Macro: count_by_value
+    Description: Counts occurrences of each value in a column.
+
+    Alteryx Equivalent: Summarize (Group By + Count)
+
+    Arguments:
+        relation: Source relation
+        column: Column to count values of
+        alias: Name for count column
+        include_null: Whether to include null as a value
+
+    Example Usage:
+        {{ count_by_value(ref('stg_orders'), 'status') }}
+#}
+
+{% macro count_by_value(relation, column, alias='count', include_null=true) %}
+
+select
+    {{ column }},
+    count(*) as {{ alias }}
+from {{ relation }}
+{% if not include_null %}
+where {{ column }} is not null
+{% endif %}
+group by {{ column }}
+order by count(*) desc
+
+{% endmacro %}
+
+
+{#
+    Macro: statistics_summary
+    Description: Calculates comprehensive statistics for a numeric column.
+
+    Alteryx Equivalent: Basic Data Profile, Summarize with multiple stats
+
+    Arguments:
+        relation: Source relation
+        column: Numeric column to analyze
+        group_by: Optional grouping columns
+
+    Example Usage:
+        {{ statistics_summary(ref('stg_sales'), 'revenue', group_by=['year']) }}
+#}
+
+{% macro statistics_summary(relation, column, group_by=none) %}
+
+select
+    {%- if group_by %}
+    {{ group_by | join(', ') }},
+    {%- endif %}
+    count(*) as record_count,
+    count({{ column }}) as non_null_count,
+    count(*) - count({{ column }}) as null_count,
+    min({{ column }}) as min_value,
+    max({{ column }}) as max_value,
+    avg({{ column }}) as mean_value,
+    approx_percentile({{ column }}, 0.5) as median_value,
+    stddev({{ column }}) as std_dev,
+    variance({{ column }}) as variance,
+    sum({{ column }}) as total_sum,
+    approx_percentile({{ column }}, 0.25) as percentile_25,
+    approx_percentile({{ column }}, 0.75) as percentile_75
+from {{ relation }}
+{%- if group_by %}
+group by {{ group_by | join(', ') }}
+{%- endif %}
+
+{% endmacro %}
+
+
+{#
+    Macro: weighted_average
+    Description: Calculates weighted average.
+
+    Alteryx Equivalent: Weighted Average tool / Summarize pattern
+
+    Arguments:
+        relation: Source relation
+        value_column: Column containing values
+        weight_column: Column containing weights
+        group_by: Optional grouping columns
+        alias: Name for result column
+
+    Example Usage:
+        {{ weighted_average(
+            relation=ref('stg_grades'),
+            value_column='score',
+            weight_column='credits',
+            group_by=['student_id'],
+            alias='gpa'
+        ) }}
+#}
+
+{% macro weighted_average(relation, value_column, weight_column, group_by=none, alias='weighted_avg') %}
+
+select
+    {%- if group_by %}
+    {{ group_by | join(', ') }},
+    {%- endif %}
+    sum({{ value_column }} * {{ weight_column }}) / nullif(sum({{ weight_column }}), 0) as {{ alias }}
+from {{ relation }}
+{%- if group_by %}
+group by {{ group_by | join(', ') }}
+{%- endif %}
+
+{% endmacro %}

--- a/dbt_macros/conditional_logic.sql
+++ b/dbt_macros/conditional_logic.sql
@@ -1,0 +1,423 @@
+{#
+    =============================================================================
+    Conditional Logic Macros
+    Alteryx Equivalent: Formula tool conditional functions
+    Trino Compatible: Yes
+    =============================================================================
+
+    These macros provide conditional logic and branching functionality
+    matching Alteryx Formula tool capabilities.
+#}
+
+{#
+    Macro: case_when
+    Description: Multi-condition CASE WHEN statement.
+
+    Alteryx Equivalent: Nested IIF or Switch function
+
+    Arguments:
+        conditions: List of [condition, result] pairs
+        else_value: Default value if no conditions match
+
+    Example Usage:
+        {{ case_when(
+            conditions=[
+                ["age < 18", "'Minor'"],
+                ["age < 65", "'Adult'"],
+                ["age >= 65", "'Senior'"]
+            ],
+            else_value="'Unknown'"
+        ) }}
+#}
+
+{% macro case_when(conditions, else_value='null') %}
+case
+    {%- for condition, result in conditions %}
+    when {{ condition }} then {{ result }}
+    {%- endfor %}
+    else {{ else_value }}
+end
+{% endmacro %}
+
+
+{#
+    Macro: case_value
+    Description: CASE expression matching specific values.
+
+    Alteryx Equivalent: Switch([field], default, val1, result1, ...)
+
+    Arguments:
+        column: Column to evaluate
+        value_map: Dictionary of value: result pairs
+        else_value: Default value
+
+    Example Usage:
+        {{ case_value(
+            'status_code',
+            value_map={'A': "'Active'", 'I': "'Inactive'", 'P': "'Pending'"},
+            else_value="'Unknown'"
+        ) }}
+#}
+
+{% macro case_value(column, value_map, else_value='null') %}
+case {{ column }}
+    {%- for val, result in value_map.items() %}
+    when '{{ val }}' then {{ result }}
+    {%- endfor %}
+    else {{ else_value }}
+end
+{% endmacro %}
+
+
+{#
+    Macro: if_null
+    Description: Returns fallback if value is null.
+
+    Alteryx Equivalent: IIF(IsNull([field]), fallback, [field])
+
+    Arguments:
+        column: Column to check
+        fallback: Value to use if null
+
+    Example Usage:
+        {{ if_null('discount', 0) }} as discount
+#}
+
+{% macro if_null(column, fallback) %}
+coalesce({{ column }}, {{ fallback }})
+{% endmacro %}
+
+
+{#
+    Macro: if_empty
+    Description: Returns fallback if value is null or empty string.
+
+    Alteryx Equivalent: IIF(IsNull([field]) OR IsEmpty([field]), fallback, [field])
+
+    Arguments:
+        column: Column to check
+        fallback: Value to use if null/empty
+
+    Example Usage:
+        {{ if_empty('notes', "'No notes'"') }} as notes
+#}
+
+{% macro if_empty(column, fallback) %}
+case
+    when {{ column }} is null or trim({{ column }}) = ''
+    then {{ fallback }}
+    else {{ column }}
+end
+{% endmacro %}
+
+
+{#
+    Macro: if_zero
+    Description: Returns fallback if value is zero.
+
+    Alteryx Equivalent: IIF([field] = 0, fallback, [field])
+
+    Arguments:
+        column: Column to check
+        fallback: Value to use if zero
+
+    Example Usage:
+        {{ if_zero('quantity', 1) }} as quantity
+#}
+
+{% macro if_zero(column, fallback) %}
+case when {{ column }} = 0 then {{ fallback }} else {{ column }} end
+{% endmacro %}
+
+
+{#
+    Macro: null_if
+    Description: Returns null if condition is true.
+
+    Alteryx Equivalent: IIF([condition], Null(), [field])
+
+    Arguments:
+        column: Column to potentially nullify
+        condition: When true, return null
+
+    Example Usage:
+        {{ null_if('value', "value = 0") }} as value_or_null
+#}
+
+{% macro null_if(column, condition) %}
+case when {{ condition }} then null else {{ column }} end
+{% endmacro %}
+
+
+{#
+    Macro: decode
+    Description: Oracle-style DECODE function.
+
+    Alteryx Equivalent: Switch function
+
+    Arguments:
+        column: Column to evaluate
+        pairs: List of [search_value, result] pairs
+        default: Default value
+
+    Example Usage:
+        {{ decode('grade', [['A', 4], ['B', 3], ['C', 2], ['D', 1], ['F', 0]], 0) }}
+#}
+
+{% macro decode(column, pairs, default='null') %}
+case {{ column }}
+    {%- for search_val, result in pairs %}
+    when {{ search_val }} then {{ result }}
+    {%- endfor %}
+    else {{ default }}
+end
+{% endmacro %}
+
+
+{#
+    Macro: between_check
+    Description: Returns boolean for between check.
+
+    Alteryx Equivalent: [field] >= lower AND [field] <= upper
+
+    Arguments:
+        column: Column to check
+        lower: Lower bound
+        upper: Upper bound
+        inclusive: Include bounds (default: true)
+
+    Example Usage:
+        {{ between_check('age', 18, 65) }} as is_working_age
+#}
+
+{% macro between_check(column, lower, upper, inclusive=true) %}
+{% if inclusive %}
+({{ column }} >= {{ lower }} and {{ column }} <= {{ upper }})
+{% else %}
+({{ column }} > {{ lower }} and {{ column }} < {{ upper }})
+{% endif %}
+{% endmacro %}
+
+
+{#
+    Macro: in_list_check
+    Description: Returns boolean for list membership.
+
+    Alteryx Equivalent: [field] IN (val1, val2, ...)
+
+    Arguments:
+        column: Column to check
+        values: List of values
+
+    Example Usage:
+        {{ in_list_check('status', ['active', 'pending']) }} as is_active_or_pending
+#}
+
+{% macro in_list_check(column, values) %}
+{{ column }} in (
+    {%- for val in values %}
+    '{{ val }}'{% if not loop.last %}, {% endif %}
+    {%- endfor %}
+)
+{% endmacro %}
+
+
+{#
+    Macro: greatest_value
+    Description: Returns the greatest of multiple values.
+
+    Alteryx Equivalent: Max([field1], [field2], ...)
+
+    Arguments:
+        values: List of columns/expressions
+
+    Example Usage:
+        {{ greatest_value(['score1', 'score2', 'score3']) }} as max_score
+#}
+
+{% macro greatest_value(values) %}
+greatest({{ values | join(', ') }})
+{% endmacro %}
+
+
+{#
+    Macro: least_value
+    Description: Returns the least of multiple values.
+
+    Alteryx Equivalent: Min([field1], [field2], ...)
+
+    Arguments:
+        values: List of columns/expressions
+
+    Example Usage:
+        {{ least_value(['price1', 'price2', 'price3']) }} as min_price
+#}
+
+{% macro least_value(values) %}
+least({{ values | join(', ') }})
+{% endmacro %}
+
+
+{#
+    Macro: nvl2
+    Description: Oracle-style NVL2 - returns expr1 if not null, else expr2.
+
+    Alteryx Equivalent: IIF(IsNull([field]), null_result, not_null_result)
+
+    Arguments:
+        column: Column to check
+        not_null_result: Result when column is not null
+        null_result: Result when column is null
+
+    Example Usage:
+        {{ nvl2('email', "'Has Email'", "'No Email'") }} as email_status
+#}
+
+{% macro nvl2(column, not_null_result, null_result) %}
+case when {{ column }} is not null then {{ not_null_result }} else {{ null_result }} end
+{% endmacro %}
+
+
+{#
+    Macro: flag_column
+    Description: Creates a boolean/integer flag based on condition.
+
+    Alteryx Equivalent: IIF([condition], 1, 0) or IIF([condition], True, False)
+
+    Arguments:
+        condition: Condition expression
+        true_value: Value when true (default: 1)
+        false_value: Value when false (default: 0)
+
+    Example Usage:
+        {{ flag_column("amount > 1000", 1, 0) }} as is_large_order
+#}
+
+{% macro flag_column(condition, true_value=1, false_value=0) %}
+case when {{ condition }} then {{ true_value }} else {{ false_value }} end
+{% endmacro %}
+
+
+{#
+    Macro: category_column
+    Description: Categorizes values into groups.
+
+    Alteryx Equivalent: Multi-level IIF or Formula categorization
+
+    Arguments:
+        column: Column to categorize
+        thresholds: List of threshold values
+        labels: List of labels (should be len(thresholds) + 1)
+        ascending: Whether thresholds are in ascending order
+
+    Example Usage:
+        {{ category_column(
+            'revenue',
+            thresholds=[1000, 10000, 100000],
+            labels=['Small', 'Medium', 'Large', 'Enterprise']
+        ) }} as customer_tier
+#}
+
+{% macro category_column(column, thresholds, labels, ascending=true) %}
+case
+    {%- if ascending %}
+        {%- for i in range(thresholds | length) %}
+    when {{ column }} <= {{ thresholds[i] }} then '{{ labels[i] }}'
+        {%- endfor %}
+    else '{{ labels[-1] }}'
+        {%- else %}
+        {%- for i in range(thresholds | length) %}
+    when {{ column }} >= {{ thresholds[i] }} then '{{ labels[i] }}'
+        {%- endfor %}
+    else '{{ labels[-1] }}'
+    {%- endif %}
+end
+{% endmacro %}
+
+
+{#
+    Macro: age_from_birthdate
+    Description: Calculates age from birthdate.
+
+    Alteryx Equivalent: DateTimeDiff formula for age
+
+    Arguments:
+        birthdate_column: Column containing birthdate
+        as_of_date: Date to calculate age as of (default: current_date)
+
+    Example Usage:
+        {{ age_from_birthdate('date_of_birth') }} as current_age
+#}
+
+{% macro age_from_birthdate(birthdate_column, as_of_date='current_date') %}
+date_diff('year', {{ birthdate_column }}, {{ as_of_date }}) -
+case
+    when date_add('year', date_diff('year', {{ birthdate_column }}, {{ as_of_date }}), {{ birthdate_column }}) > {{ as_of_date }}
+    then 1
+    else 0
+end
+{% endmacro %}
+
+
+{#
+    Macro: days_until
+    Description: Calculates days until a future date.
+
+    Alteryx Equivalent: DateTimeDiff formula
+
+    Arguments:
+        target_date: Target date column
+        from_date: Starting date (default: current_date)
+
+    Example Usage:
+        {{ days_until('expiration_date') }} as days_to_expiry
+#}
+
+{% macro days_until(target_date, from_date='current_date') %}
+date_diff('day', {{ from_date }}, {{ target_date }})
+{% endmacro %}
+
+
+{#
+    Macro: is_weekend
+    Description: Returns true if date is a weekend.
+
+    Alteryx Equivalent: Formula with day of week check
+
+    Arguments:
+        date_column: Date column to check
+
+    Example Usage:
+        {{ is_weekend('order_date') }} as is_weekend_order
+#}
+
+{% macro is_weekend(date_column) %}
+day_of_week({{ date_column }}) in (6, 7)
+{% endmacro %}
+
+
+{#
+    Macro: fiscal_year
+    Description: Calculates fiscal year from date.
+
+    Alteryx Equivalent: Formula for fiscal year
+
+    Arguments:
+        date_column: Date column
+        fiscal_start_month: First month of fiscal year (default: 1 = January)
+
+    Example Usage:
+        {{ fiscal_year('transaction_date', 7) }} as fiscal_year  -- July fiscal year start
+#}
+
+{% macro fiscal_year(date_column, fiscal_start_month=1) %}
+{% if fiscal_start_month == 1 %}
+year({{ date_column }})
+{% else %}
+case
+    when month({{ date_column }}) >= {{ fiscal_start_month }}
+    then year({{ date_column }}) + 1
+    else year({{ date_column }})
+end
+{% endif %}
+{% endmacro %}

--- a/dbt_macros/filter_helpers.sql
+++ b/dbt_macros/filter_helpers.sql
@@ -1,0 +1,335 @@
+{#
+    =============================================================================
+    Filter Helper Macros
+    Alteryx Equivalent: Filter tool
+    Trino Compatible: Yes
+    =============================================================================
+
+    These macros help construct WHERE clause conditions for filtering data,
+    replicating Alteryx Filter tool functionality.
+#}
+
+{#
+    Macro: filter_expression
+    Description: Applies a filter condition to a relation.
+
+    Alteryx Equivalent: Filter tool (Custom mode)
+
+    Arguments:
+        relation: The source relation
+        condition: SQL WHERE condition expression
+
+    Example Usage:
+        {{ filter_expression(
+            relation=ref('stg_orders'),
+            condition="order_amount > 100 and status = 'completed'"
+        ) }}
+#}
+
+{% macro filter_expression(relation, condition) %}
+
+select *
+from {{ relation }}
+where {{ condition }}
+
+{% endmacro %}
+
+
+{#
+    Macro: filter_in_list
+    Description: Filters rows where column value is in a list.
+
+    Alteryx Equivalent: Filter tool with "OR" conditions
+
+    Arguments:
+        relation: The source relation
+        column: Column to filter on
+        values: List of values to include
+        include: If true, keep matching rows; if false, exclude them (default: true)
+
+    Example Usage:
+        {{ filter_in_list(
+            relation=ref('stg_orders'),
+            column='status',
+            values=['pending', 'processing', 'shipped']
+        ) }}
+#}
+
+{% macro filter_in_list(relation, column, values, include=true) %}
+
+select *
+from {{ relation }}
+where {{ column }} {% if not include %}not {% endif %}in (
+    {%- for val in values %}
+    '{{ val }}'{% if not loop.last %}, {% endif %}
+    {%- endfor %}
+)
+
+{% endmacro %}
+
+
+{#
+    Macro: filter_between
+    Description: Filters rows where column value is between two values.
+
+    Alteryx Equivalent: Filter tool with range condition
+
+    Arguments:
+        relation: The source relation
+        column: Column to filter on
+        lower_bound: Lower bound value (inclusive)
+        upper_bound: Upper bound value (inclusive)
+        include_bounds: Whether bounds are inclusive (default: true)
+
+    Example Usage:
+        {{ filter_between(
+            relation=ref('stg_sales'),
+            column='order_date',
+            lower_bound="date '2024-01-01'",
+            upper_bound="date '2024-12-31'"
+        ) }}
+#}
+
+{% macro filter_between(relation, column, lower_bound, upper_bound, include_bounds=true) %}
+
+select *
+from {{ relation }}
+{% if include_bounds %}
+where {{ column }} between {{ lower_bound }} and {{ upper_bound }}
+{% else %}
+where {{ column }} > {{ lower_bound }} and {{ column }} < {{ upper_bound }}
+{% endif %}
+
+{% endmacro %}
+
+
+{#
+    Macro: filter_null
+    Description: Filters rows based on null/not null values.
+
+    Alteryx Equivalent: Filter tool with IsNull condition
+
+    Arguments:
+        relation: The source relation
+        column: Column to check
+        keep_nulls: If true, keep null rows; if false, keep non-null rows (default: false)
+
+    Example Usage:
+        {{ filter_null(ref('stg_customers'), 'email', keep_nulls=false) }}
+#}
+
+{% macro filter_null(relation, column, keep_nulls=false) %}
+
+select *
+from {{ relation }}
+where {{ column }} is {% if not keep_nulls %}not {% endif %}null
+
+{% endmacro %}
+
+
+{#
+    Macro: filter_empty
+    Description: Filters rows based on empty/non-empty string values.
+
+    Alteryx Equivalent: Filter tool with IsEmpty condition
+
+    Arguments:
+        relation: The source relation
+        column: Column to check
+        keep_empty: If true, keep empty rows; if false, keep non-empty rows (default: false)
+        include_null: Whether to treat null as empty (default: true)
+
+    Example Usage:
+        {{ filter_empty(ref('stg_customers'), 'phone', keep_empty=false) }}
+#}
+
+{% macro filter_empty(relation, column, keep_empty=false, include_null=true) %}
+
+select *
+from {{ relation }}
+{% if keep_empty %}
+where trim(coalesce({{ column }}, '')) = ''
+{% else %}
+where trim(coalesce({{ column }}, '')) <> ''
+{% endif %}
+
+{% endmacro %}
+
+
+{#
+    Macro: filter_like
+    Description: Filters rows using LIKE pattern matching.
+
+    Alteryx Equivalent: Filter tool with Contains/StartsWith/EndsWith
+
+    Arguments:
+        relation: The source relation
+        column: Column to search
+        pattern: LIKE pattern (use % and _ wildcards)
+        case_sensitive: Whether match is case-sensitive (default: true)
+
+    Example Usage:
+        {{ filter_like(ref('stg_products'), 'product_name', '%widget%', case_sensitive=false) }}
+#}
+
+{% macro filter_like(relation, column, pattern, case_sensitive=true) %}
+
+select *
+from {{ relation }}
+{% if case_sensitive %}
+where {{ column }} like '{{ pattern }}'
+{% else %}
+where lower({{ column }}) like lower('{{ pattern }}')
+{% endif %}
+
+{% endmacro %}
+
+
+{#
+    Macro: filter_regex
+    Description: Filters rows using regular expression matching.
+
+    Alteryx Equivalent: Filter tool with REGEX_Match condition
+
+    Arguments:
+        relation: The source relation
+        column: Column to search
+        pattern: Regular expression pattern
+        match: If true, keep matching rows; if false, keep non-matching (default: true)
+
+    Example Usage:
+        {{ filter_regex(ref('stg_orders'), 'order_id', '^ORD-[0-9]{6}$') }}
+#}
+
+{% macro filter_regex(relation, column, pattern, match=true) %}
+
+select *
+from {{ relation }}
+where {% if not match %}not {% endif %}regexp_like({{ column }}, '{{ pattern }}')
+
+{% endmacro %}
+
+
+{#
+    Macro: filter_date_range
+    Description: Filters rows within a date range with common presets.
+
+    Alteryx Equivalent: Filter tool with date conditions
+
+    Arguments:
+        relation: The source relation
+        date_column: Date column to filter
+        range_type: 'last_n_days', 'this_month', 'this_quarter', 'this_year',
+                    'ytd', 'mtd', 'custom'
+        n_days: Number of days for 'last_n_days' (default: 30)
+        start_date: Start date for 'custom' range
+        end_date: End date for 'custom' range
+
+    Example Usage:
+        {{ filter_date_range(ref('stg_orders'), 'order_date', range_type='last_n_days', n_days=90) }}
+#}
+
+{% macro filter_date_range(relation, date_column, range_type='last_n_days', n_days=30, start_date=none, end_date=none) %}
+
+select *
+from {{ relation }}
+where
+{% if range_type == 'last_n_days' %}
+    {{ date_column }} >= current_date - interval '{{ n_days }}' day
+{% elif range_type == 'this_month' %}
+    {{ date_column }} >= date_trunc('month', current_date)
+    and {{ date_column }} < date_trunc('month', current_date) + interval '1' month
+{% elif range_type == 'this_quarter' %}
+    {{ date_column }} >= date_trunc('quarter', current_date)
+    and {{ date_column }} < date_trunc('quarter', current_date) + interval '3' month
+{% elif range_type == 'this_year' %}
+    {{ date_column }} >= date_trunc('year', current_date)
+{% elif range_type == 'ytd' %}
+    {{ date_column }} >= date_trunc('year', current_date)
+    and {{ date_column }} <= current_date
+{% elif range_type == 'mtd' %}
+    {{ date_column }} >= date_trunc('month', current_date)
+    and {{ date_column }} <= current_date
+{% elif range_type == 'custom' %}
+    {{ date_column }} >= {{ start_date }}
+    and {{ date_column }} <= {{ end_date }}
+{% else %}
+    1=1
+{% endif %}
+
+{% endmacro %}
+
+
+{#
+    Macro: filter_multiple
+    Description: Applies multiple filter conditions with AND/OR logic.
+
+    Alteryx Equivalent: Filter tool with complex conditions
+
+    Arguments:
+        relation: The source relation
+        conditions: List of condition strings
+        logic: 'and' or 'or' (default: 'and')
+
+    Example Usage:
+        {{ filter_multiple(
+            relation=ref('stg_orders'),
+            conditions=[
+                "status = 'active'",
+                "amount > 100",
+                "region in ('North', 'South')"
+            ],
+            logic='and'
+        ) }}
+#}
+
+{% macro filter_multiple(relation, conditions, logic='and') %}
+
+select *
+from {{ relation }}
+where (
+    {%- for condition in conditions %}
+    ({{ condition }}){% if not loop.last %} {{ logic }} {% endif %}
+    {%- endfor %}
+)
+
+{% endmacro %}
+
+
+{#
+    Macro: filter_duplicates
+    Description: Filters to show only duplicate or unique rows.
+
+    Alteryx Equivalent: Filter + Unique tool combination
+
+    Arguments:
+        relation: The source relation
+        key_columns: Columns that define uniqueness
+        keep_type: 'duplicates' (rows appearing more than once) or 'unique' (rows appearing exactly once)
+
+    Example Usage:
+        {{ filter_duplicates(ref('stg_orders'), ['customer_id', 'order_date'], 'duplicates') }}
+#}
+
+{% macro filter_duplicates(relation, key_columns, keep_type='duplicates') %}
+
+with counted as (
+    select
+        *,
+        count(*) over (partition by {{ key_columns | join(', ') }}) as _occurrence_count
+    from {{ relation }}
+)
+
+select
+    {%- set columns = adapter.get_columns_in_relation(relation) %}
+    {%- for column in columns %}
+    {{ column.name }}{% if not loop.last %},{% endif %}
+    {%- endfor %}
+from counted
+{% if keep_type == 'duplicates' %}
+where _occurrence_count > 1
+{% else %}
+where _occurrence_count = 1
+{% endif %}
+
+{% endmacro %}

--- a/dbt_macros/find_replace.sql
+++ b/dbt_macros/find_replace.sql
@@ -1,0 +1,339 @@
+{#
+    =============================================================================
+    Find and Replace Macros
+    Alteryx Equivalent: Find Replace tool
+    Trino Compatible: Yes
+    =============================================================================
+
+    These macros provide find/replace functionality including pattern matching,
+    lookup-based replacement, and value translation.
+#}
+
+{#
+    Macro: find_replace_simple
+    Description: Simple find and replace on a single column.
+
+    Alteryx Equivalent: Find Replace tool (simple mode)
+
+    Arguments:
+        column: Column to perform replacement on
+        find_value: Value to find
+        replace_value: Value to replace with
+
+    Example Usage:
+        {{ find_replace_simple('status', 'Active', 'A') }}
+#}
+
+{% macro find_replace_simple(column, find_value, replace_value) %}
+replace({{ column }}, '{{ find_value }}', '{{ replace_value }}')
+{% endmacro %}
+
+
+{#
+    Macro: find_replace_multiple
+    Description: Multiple find/replace operations on a column.
+
+    Alteryx Equivalent: Find Replace tool with multiple replacements
+
+    Arguments:
+        column: Column to perform replacements on
+        replacements: Dictionary of find: replace pairs
+
+    Example Usage:
+        {{ find_replace_multiple(
+            'status',
+            {'Active': 'A', 'Inactive': 'I', 'Pending': 'P'}
+        ) }}
+#}
+
+{% macro find_replace_multiple(column, replacements) %}
+{%- set result = column -%}
+{%- for find_val, replace_val in replacements.items() -%}
+    {%- set result = "replace(" ~ result ~ ", '" ~ find_val ~ "', '" ~ replace_val ~ "')" -%}
+{%- endfor -%}
+{{ result }}
+{% endmacro %}
+
+
+{#
+    Macro: find_replace_regex
+    Description: Find and replace using regular expression.
+
+    Alteryx Equivalent: Find Replace tool with RegEx mode
+
+    Arguments:
+        column: Column to perform replacement on
+        pattern: Regular expression pattern to find
+        replacement: Replacement string (can use capture groups $1, $2, etc.)
+
+    Example Usage:
+        {{ find_replace_regex('phone', '[^0-9]', '') }}
+#}
+
+{% macro find_replace_regex(column, pattern, replacement) %}
+regexp_replace({{ column }}, '{{ pattern }}', '{{ replacement }}')
+{% endmacro %}
+
+
+{#
+    Macro: find_replace_first
+    Description: Replace only the first occurrence of a pattern.
+
+    Alteryx Equivalent: Find Replace with "Replace First" option
+
+    Arguments:
+        column: Column to perform replacement on
+        find_value: Value to find
+        replace_value: Value to replace with
+
+    Example Usage:
+        {{ find_replace_first('text', 'foo', 'bar') }}
+#}
+
+{% macro find_replace_first(column, find_value, replace_value) %}
+{# Trino's regexp_replace can limit replacements #}
+regexp_replace({{ column }}, '{{ find_value }}', '{{ replace_value }}', 1)
+{% endmacro %}
+
+
+{#
+    Macro: find_replace_lookup
+    Description: Replace values based on a lookup table/relation.
+
+    Alteryx Equivalent: Find Replace tool with lookup from another input
+
+    Arguments:
+        relation: The source relation
+        column: Column to perform replacement on
+        lookup_relation: Lookup table/relation
+        lookup_find: Column in lookup containing values to find
+        lookup_replace: Column in lookup containing replacement values
+        keep_original: If no match found, keep original value (default: true)
+
+    Example Usage:
+        {{ find_replace_lookup(
+            relation=ref('stg_orders'),
+            column='status_code',
+            lookup_relation=ref('status_mapping'),
+            lookup_find='code',
+            lookup_replace='description',
+            keep_original=true
+        ) }}
+#}
+
+{% macro find_replace_lookup(relation, column, lookup_relation, lookup_find, lookup_replace, keep_original=true) %}
+
+select
+    {%- set all_columns = adapter.get_columns_in_relation(relation) %}
+    {%- for col in all_columns %}
+        {%- if col.name == column %}
+    {% if keep_original %}coalesce(lkp.{{ lookup_replace }}, t.{{ column }}){% else %}lkp.{{ lookup_replace }}{% endif %} as {{ column }}
+        {%- else %}
+    t.{{ col.name }}
+        {%- endif %}
+        {%- if not loop.last %},{% endif %}
+    {%- endfor %}
+from {{ relation }} t
+left join {{ lookup_relation }} lkp
+    on t.{{ column }} = lkp.{{ lookup_find }}
+
+{% endmacro %}
+
+
+{#
+    Macro: translate_chars
+    Description: Character-by-character translation.
+
+    Alteryx Equivalent: REGEX_Replace for character replacement
+
+    Arguments:
+        column: Column to translate
+        from_chars: Characters to replace
+        to_chars: Replacement characters (same length as from_chars)
+
+    Example Usage:
+        {{ translate_chars('sku', 'ABC', '123') }}
+#}
+
+{% macro translate_chars(column, from_chars, to_chars) %}
+translate({{ column }}, '{{ from_chars }}', '{{ to_chars }}')
+{% endmacro %}
+
+
+{#
+    Macro: remove_chars
+    Description: Remove specific characters from a string.
+
+    Alteryx Equivalent: REGEX_Replace to remove characters
+
+    Arguments:
+        column: Column to clean
+        chars_to_remove: String of characters to remove
+
+    Example Usage:
+        {{ remove_chars('phone', '()-. ') }}
+#}
+
+{% macro remove_chars(column, chars_to_remove) %}
+translate({{ column }}, '{{ chars_to_remove }}', '')
+{% endmacro %}
+
+
+{#
+    Macro: keep_only_chars
+    Description: Keep only specified character types.
+
+    Alteryx Equivalent: REGEX_Replace with character class
+
+    Arguments:
+        column: Column to filter
+        keep_type: 'alphanumeric', 'numeric', 'alpha', 'printable'
+
+    Example Usage:
+        {{ keep_only_chars('product_code', 'alphanumeric') }}
+#}
+
+{% macro keep_only_chars(column, keep_type='alphanumeric') %}
+{% if keep_type == 'numeric' %}
+regexp_replace({{ column }}, '[^0-9]', '')
+{% elif keep_type == 'alpha' %}
+regexp_replace({{ column }}, '[^a-zA-Z]', '')
+{% elif keep_type == 'alphanumeric' %}
+regexp_replace({{ column }}, '[^a-zA-Z0-9]', '')
+{% elif keep_type == 'printable' %}
+regexp_replace({{ column }}, '[^\\x20-\\x7E]', '')
+{% else %}
+{{ column }}
+{% endif %}
+{% endmacro %}
+
+
+{#
+    Macro: conditional_replace
+    Description: Replace values conditionally based on a condition.
+
+    Alteryx Equivalent: Formula with IIF for conditional replacement
+
+    Arguments:
+        column: Column to potentially replace
+        condition: When this condition is true
+        new_value: Value to use when condition is true
+        else_value: Value when condition is false (default: original column)
+
+    Example Usage:
+        {{ conditional_replace('status', "status = 'UNKNOWN'", "'N/A'") }}
+#}
+
+{% macro conditional_replace(column, condition, new_value, else_value=none) %}
+case when {{ condition }} then {{ new_value }} else {% if else_value %}{{ else_value }}{% else %}{{ column }}{% endif %} end
+{% endmacro %}
+
+
+{#
+    Macro: case_mapping
+    Description: Map values using CASE expression.
+
+    Alteryx Equivalent: Find Replace with value mapping
+
+    Arguments:
+        column: Column to map
+        mappings: Dictionary of value: replacement pairs
+        default: Default value if no match (default: original value)
+
+    Example Usage:
+        {{ case_mapping(
+            'grade_code',
+            {'A': 'Excellent', 'B': 'Good', 'C': 'Average', 'D': 'Below Average'},
+            "'Other'"
+        ) }}
+#}
+
+{% macro case_mapping(column, mappings, default=none) %}
+case {{ column }}
+    {%- for find_val, replace_val in mappings.items() %}
+    when '{{ find_val }}' then {{ replace_val }}
+    {%- endfor %}
+    else {% if default %}{{ default }}{% else %}{{ column }}{% endif %}
+end
+{% endmacro %}
+
+
+{#
+    Macro: apply_find_replace
+    Description: Applies find/replace to a relation, updating a column.
+
+    Alteryx Equivalent: Find Replace tool output
+
+    Arguments:
+        relation: Source relation
+        column: Column to update
+        find_value: Value to find
+        replace_value: Replacement value
+        use_regex: Whether to use regex matching (default: false)
+        case_sensitive: Whether matching is case-sensitive (default: true)
+
+    Example Usage:
+        {{ apply_find_replace(
+            relation=ref('stg_addresses'),
+            column='state',
+            find_value='Calif.',
+            replace_value='California'
+        ) }}
+#}
+
+{% macro apply_find_replace(relation, column, find_value, replace_value, use_regex=false, case_sensitive=true) %}
+
+select
+    {%- set all_columns = adapter.get_columns_in_relation(relation) %}
+    {%- for col in all_columns %}
+        {%- if col.name == column %}
+            {%- if use_regex %}
+    regexp_replace({{ col.name }}, '{{ find_value }}', '{{ replace_value }}') as {{ col.name }}
+            {%- elif not case_sensitive %}
+    case
+        when lower({{ col.name }}) like lower('%{{ find_value }}%')
+        then replace(lower({{ col.name }}), lower('{{ find_value }}'), '{{ replace_value }}')
+        else {{ col.name }}
+    end as {{ col.name }}
+            {%- else %}
+    replace({{ col.name }}, '{{ find_value }}', '{{ replace_value }}') as {{ col.name }}
+            {%- endif %}
+        {%- else %}
+    {{ col.name }}
+        {%- endif %}
+        {%- if not loop.last %},{% endif %}
+    {%- endfor %}
+from {{ relation }}
+
+{% endmacro %}
+
+
+{#
+    Macro: standardize_values
+    Description: Standardize inconsistent values to canonical form.
+
+    Alteryx Equivalent: Find Replace for data standardization
+
+    Arguments:
+        column: Column to standardize
+        standard_value: The canonical/standard value
+        variations: List of variations to standardize
+
+    Example Usage:
+        {{ standardize_values(
+            'country',
+            'United States',
+            ['US', 'USA', 'U.S.', 'U.S.A.', 'United States of America']
+        ) }}
+#}
+
+{% macro standardize_values(column, standard_value, variations) %}
+case
+    when {{ column }} in (
+        {%- for var in variations %}
+        '{{ var }}'{% if not loop.last %}, {% endif %}
+        {%- endfor %}
+    ) then '{{ standard_value }}'
+    else {{ column }}
+end
+{% endmacro %}

--- a/dbt_macros/formula_helpers.sql
+++ b/dbt_macros/formula_helpers.sql
@@ -1,0 +1,489 @@
+{#
+    =============================================================================
+    Formula Helper Macros
+    Alteryx Equivalent: Formula tool, Multi-Field Formula
+    Trino Compatible: Yes
+    =============================================================================
+
+    These macros provide common formula patterns used in Alteryx Formula tool,
+    converted to Trino SQL syntax.
+#}
+
+{#
+    Macro: iif
+    Description: Inline if-then-else (CASE WHEN equivalent).
+
+    Alteryx Equivalent: IIF([condition], true_result, false_result)
+
+    Arguments:
+        condition: Boolean condition
+        true_value: Value when condition is true
+        false_value: Value when condition is false
+
+    Example Usage:
+        select {{ iif('amount > 1000', "'high'", "'low'") }} as priority
+#}
+
+{% macro iif(condition, true_value, false_value) %}
+case when {{ condition }} then {{ true_value }} else {{ false_value }} end
+{% endmacro %}
+
+
+{#
+    Macro: switch
+    Description: Multi-value switch statement (like Alteryx Switch function).
+
+    Alteryx Equivalent: Switch([field], default, val1, result1, val2, result2, ...)
+
+    Arguments:
+        value: Expression to evaluate
+        cases: Dictionary of value: result pairs
+        default: Default value if no match
+
+    Example Usage:
+        {{ switch(
+            'status_code',
+            cases={'A': "'Active'", 'I': "'Inactive'", 'P': "'Pending'"},
+            default="'Unknown'"
+        ) }}
+#}
+
+{% macro switch(value, cases, default="null") %}
+case {{ value }}
+    {%- for case_val, result in cases.items() %}
+    when '{{ case_val }}' then {{ result }}
+    {%- endfor %}
+    else {{ default }}
+end
+{% endmacro %}
+
+
+{#
+    Macro: switch_true
+    Description: Multi-condition switch (CASE WHEN without value).
+
+    Alteryx Equivalent: Nested IIF or IF-THEN-ELSEIF
+
+    Arguments:
+        conditions: List of [condition, result] pairs (evaluated in order)
+        default: Default value if no condition matches
+
+    Example Usage:
+        {{ switch_true(
+            conditions=[
+                ["score >= 90", "'A'"],
+                ["score >= 80", "'B'"],
+                ["score >= 70", "'C'"],
+                ["score >= 60", "'D'"]
+            ],
+            default="'F'"
+        ) }}
+#}
+
+{% macro switch_true(conditions, default="null") %}
+case
+    {%- for condition, result in conditions %}
+    when {{ condition }} then {{ result }}
+    {%- endfor %}
+    else {{ default }}
+end
+{% endmacro %}
+
+
+{#
+    Macro: null_coalesce
+    Description: Returns first non-null value from a list of expressions.
+
+    Alteryx Equivalent: Coalesce() or nested IsNull() checks
+
+    Arguments:
+        values: List of expressions to check
+
+    Example Usage:
+        {{ null_coalesce(['phone_mobile', 'phone_home', 'phone_work', "'N/A'"]) }}
+#}
+
+{% macro null_coalesce(values) %}
+coalesce({{ values | join(', ') }})
+{% endmacro %}
+
+
+{#
+    Macro: is_null
+    Description: Returns boolean indicating if value is null.
+
+    Alteryx Equivalent: IsNull([field])
+
+    Arguments:
+        column: Column to check
+
+    Example Usage:
+        where {{ is_null('email') }} = true
+#}
+
+{% macro is_null(column) %}
+({{ column }} is null)
+{% endmacro %}
+
+
+{#
+    Macro: is_empty
+    Description: Returns boolean indicating if value is empty string.
+
+    Alteryx Equivalent: IsEmpty([field])
+
+    Arguments:
+        column: Column to check
+        trim_first: Trim whitespace before checking (default: true)
+
+    Example Usage:
+        where {{ is_empty('notes') }} = true
+#}
+
+{% macro is_empty(column, trim_first=true) %}
+{% if trim_first %}
+(trim({{ column }}) = '')
+{% else %}
+({{ column }} = '')
+{% endif %}
+{% endmacro %}
+
+
+{#
+    Macro: is_null_or_empty
+    Description: Returns boolean indicating if value is null OR empty.
+
+    Alteryx Equivalent: IsNull([field]) OR IsEmpty([field])
+
+    Arguments:
+        column: Column to check
+
+    Example Usage:
+        where {{ is_null_or_empty('customer_name') }} = false
+#}
+
+{% macro is_null_or_empty(column) %}
+({{ column }} is null or trim({{ column }}) = '')
+{% endmacro %}
+
+
+{#
+    Macro: default_if_null
+    Description: Returns default value if expression is null.
+
+    Alteryx Equivalent: IIF(IsNull([field]), default, [field])
+
+    Arguments:
+        column: Column to check
+        default: Default value to use
+
+    Example Usage:
+        {{ default_if_null('discount', '0') }} as discount
+#}
+
+{% macro default_if_null(column, default) %}
+coalesce({{ column }}, {{ default }})
+{% endmacro %}
+
+
+{#
+    Macro: default_if_empty
+    Description: Returns default value if expression is null or empty.
+
+    Alteryx Equivalent: IIF(IsNull([field]) OR IsEmpty([field]), default, [field])
+
+    Arguments:
+        column: Column to check
+        default: Default value to use
+
+    Example Usage:
+        {{ default_if_empty('notes', "'No notes'"') }} as notes
+#}
+
+{% macro default_if_empty(column, default) %}
+case when {{ column }} is null or trim({{ column }}) = '' then {{ default }} else {{ column }} end
+{% endmacro %}
+
+
+{#
+    Macro: nullif_value
+    Description: Returns null if column equals specified value.
+
+    Alteryx Equivalent: IIF([field] = value, Null(), [field])
+
+    Arguments:
+        column: Column to check
+        value: Value that should become null
+
+    Example Usage:
+        {{ nullif_value('status', "'N/A'") }} as status
+#}
+
+{% macro nullif_value(column, value) %}
+nullif({{ column }}, {{ value }})
+{% endmacro %}
+
+
+{#
+    Macro: concat_fields
+    Description: Concatenates multiple fields with optional separator.
+
+    Alteryx Equivalent: [field1] + [field2] or Concat()
+
+    Arguments:
+        columns: List of column names/expressions
+        separator: Separator between values (default: '')
+        skip_nulls: If true, skip null values (default: true)
+
+    Example Usage:
+        {{ concat_fields(['first_name', '" "', 'last_name'], separator='') }} as full_name
+#}
+
+{% macro concat_fields(columns, separator='', skip_nulls=true) %}
+{% if skip_nulls %}
+array_join(
+    filter(
+        array[{%- for col in columns %}cast({{ col }} as varchar){% if not loop.last %}, {% endif %}{%- endfor %}],
+        x -> x is not null
+    ),
+    '{{ separator }}'
+)
+{% else %}
+concat({%- for col in columns %}{{ col }}{% if not loop.last %}, {% endif %}{%- endfor %})
+{% endif %}
+{% endmacro %}
+
+
+{#
+    Macro: substring_extract
+    Description: Extracts substring from a string.
+
+    Alteryx Equivalent: Substring([field], start, length)
+
+    Arguments:
+        column: Source column
+        start: Starting position (1-indexed)
+        length: Number of characters to extract (optional)
+
+    Example Usage:
+        {{ substring_extract('phone', 1, 3) }} as area_code
+#}
+
+{% macro substring_extract(column, start, length=none) %}
+{% if length %}
+substr({{ column }}, {{ start }}, {{ length }})
+{% else %}
+substr({{ column }}, {{ start }})
+{% endif %}
+{% endmacro %}
+
+
+{#
+    Macro: left_chars
+    Description: Extracts left N characters.
+
+    Alteryx Equivalent: Left([field], n)
+
+    Arguments:
+        column: Source column
+        n: Number of characters
+
+    Example Usage:
+        {{ left_chars('postal_code', 5) }} as zip5
+#}
+
+{% macro left_chars(column, n) %}
+substr({{ column }}, 1, {{ n }})
+{% endmacro %}
+
+
+{#
+    Macro: right_chars
+    Description: Extracts right N characters.
+
+    Alteryx Equivalent: Right([field], n)
+
+    Arguments:
+        column: Source column
+        n: Number of characters
+
+    Example Usage:
+        {{ right_chars('phone', 4) }} as last_four
+#}
+
+{% macro right_chars(column, n) %}
+substr({{ column }}, length({{ column }}) - {{ n }} + 1)
+{% endmacro %}
+
+
+{#
+    Macro: add_calculated_column
+    Description: Adds a calculated column to a relation.
+
+    Alteryx Equivalent: Formula tool adding new field
+
+    Arguments:
+        relation: Source relation
+        column_name: Name for new column
+        expression: SQL expression for the calculation
+
+    Example Usage:
+        {{ add_calculated_column(
+            relation=ref('stg_orders'),
+            column_name='total_with_tax',
+            expression='amount * (1 + tax_rate)'
+        ) }}
+#}
+
+{% macro add_calculated_column(relation, column_name, expression) %}
+
+select
+    *,
+    {{ expression }} as {{ column_name }}
+from {{ relation }}
+
+{% endmacro %}
+
+
+{#
+    Macro: add_multiple_columns
+    Description: Adds multiple calculated columns at once.
+
+    Alteryx Equivalent: Formula tool with multiple expressions, Multi-Field Formula
+
+    Arguments:
+        relation: Source relation
+        columns: Dictionary of column_name: expression pairs
+
+    Example Usage:
+        {{ add_multiple_columns(
+            relation=ref('stg_orders'),
+            columns={
+                'total': 'quantity * unit_price',
+                'with_tax': 'quantity * unit_price * 1.08',
+                'is_large': "case when quantity > 100 then true else false end"
+            }
+        ) }}
+#}
+
+{% macro add_multiple_columns(relation, columns) %}
+
+select
+    *,
+    {%- for col_name, expression in columns.items() %}
+    {{ expression }} as {{ col_name }}{% if not loop.last %},{% endif %}
+    {%- endfor %}
+from {{ relation }}
+
+{% endmacro %}
+
+
+{#
+    Macro: update_column
+    Description: Updates an existing column with a new expression.
+
+    Alteryx Equivalent: Formula tool overwriting existing field
+
+    Arguments:
+        relation: Source relation
+        column_name: Column to update
+        expression: New expression for the column
+        include_original: Keep original as _original suffix (default: false)
+
+    Example Usage:
+        {{ update_column(
+            relation=ref('stg_customers'),
+            column_name='phone',
+            expression="regexp_replace(phone, '[^0-9]', '')"
+        ) }}
+#}
+
+{% macro update_column(relation, column_name, expression, include_original=false) %}
+
+select
+    {%- set all_columns = adapter.get_columns_in_relation(relation) %}
+    {%- for column in all_columns %}
+        {%- if column.name == column_name %}
+            {%- if include_original %}
+    {{ column.name }} as {{ column.name }}_original,
+            {%- endif %}
+    {{ expression }} as {{ column.name }}
+        {%- else %}
+    {{ column.name }}
+        {%- endif %}
+        {%- if not loop.last %},{% endif %}
+    {%- endfor %}
+from {{ relation }}
+
+{% endmacro %}
+
+
+{#
+    Macro: string_length
+    Description: Returns length of string.
+
+    Alteryx Equivalent: Length([field])
+
+    Arguments:
+        column: Column to measure
+
+    Example Usage:
+        {{ string_length('description') }} as desc_length
+#}
+
+{% macro string_length(column) %}
+length({{ column }})
+{% endmacro %}
+
+
+{#
+    Macro: trim_all
+    Description: Trims whitespace from string.
+
+    Alteryx Equivalent: Trim([field])
+
+    Arguments:
+        column: Column to trim
+        side: 'both', 'left', 'right' (default: 'both')
+
+    Example Usage:
+        {{ trim_all('name', 'both') }} as name_trimmed
+#}
+
+{% macro trim_all(column, side='both') %}
+{% if side == 'left' %}
+ltrim({{ column }})
+{% elif side == 'right' %}
+rtrim({{ column }})
+{% else %}
+trim({{ column }})
+{% endif %}
+{% endmacro %}
+
+
+{#
+    Macro: change_case
+    Description: Changes string case.
+
+    Alteryx Equivalent: UpperCase(), LowerCase(), TitleCase()
+
+    Arguments:
+        column: Column to transform
+        case_type: 'upper', 'lower', 'proper' (default: 'lower')
+
+    Example Usage:
+        {{ change_case('name', 'proper') }} as name_proper
+#}
+
+{% macro change_case(column, case_type='lower') %}
+{% if case_type == 'upper' %}
+upper({{ column }})
+{% elif case_type == 'lower' %}
+lower({{ column }})
+{% elif case_type == 'proper' %}
+{# Trino doesn't have native INITCAP, use pattern replacement #}
+regexp_replace(lower({{ column }}), '(\s|^)(\w)', x -> upper(x))
+{% else %}
+{{ column }}
+{% endif %}
+{% endmacro %}

--- a/dbt_macros/imputation.sql
+++ b/dbt_macros/imputation.sql
@@ -1,0 +1,450 @@
+{#
+    =============================================================================
+    Imputation Macros
+    Alteryx Equivalent: Imputation tool
+    Trino Compatible: Yes
+    =============================================================================
+
+    These macros provide missing value imputation functionality including
+    mean, median, mode, and custom imputation strategies.
+#}
+
+{#
+    Macro: impute_with_value
+    Description: Replace null values with a specified value.
+
+    Alteryx Equivalent: Imputation tool (user-specified value mode)
+
+    Arguments:
+        column: Column to impute
+        value: Value to use for imputation
+
+    Example Usage:
+        {{ impute_with_value('score', 0) }}
+#}
+
+{% macro impute_with_value(column, value) %}
+coalesce({{ column }}, {{ value }})
+{% endmacro %}
+
+
+{#
+    Macro: impute_with_mean
+    Description: Replace null values with the mean of the column.
+
+    Alteryx Equivalent: Imputation tool (average mode)
+
+    Arguments:
+        relation: Source relation
+        column: Column to impute
+        group_by: Optional columns for grouped imputation
+
+    Example Usage:
+        {{ impute_with_mean(ref('stg_sales'), 'quantity') }}
+        {{ impute_with_mean(ref('stg_sales'), 'quantity', group_by=['region']) }}
+#}
+
+{% macro impute_with_mean(relation, column, group_by=none) %}
+
+{% if group_by %}
+with avg_values as (
+    select
+        {{ group_by | join(', ') }},
+        avg({{ column }}) as _impute_value
+    from {{ relation }}
+    where {{ column }} is not null
+    group by {{ group_by | join(', ') }}
+)
+
+select
+    {%- set all_columns = adapter.get_columns_in_relation(relation) %}
+    {%- for col in all_columns %}
+        {%- if col.name == column %}
+    coalesce(t.{{ column }}, a._impute_value) as {{ column }}
+        {%- else %}
+    t.{{ col.name }}
+        {%- endif %}
+        {%- if not loop.last %},{% endif %}
+    {%- endfor %}
+from {{ relation }} t
+left join avg_values a on
+    {%- for gc in group_by %}
+    t.{{ gc }} = a.{{ gc }}{% if not loop.last %} and {% endif %}
+    {%- endfor %}
+{% else %}
+select
+    {%- set all_columns = adapter.get_columns_in_relation(relation) %}
+    {%- for col in all_columns %}
+        {%- if col.name == column %}
+    coalesce({{ column }}, (select avg({{ column }}) from {{ relation }} where {{ column }} is not null)) as {{ column }}
+        {%- else %}
+    {{ col.name }}
+        {%- endif %}
+        {%- if not loop.last %},{% endif %}
+    {%- endfor %}
+from {{ relation }}
+{% endif %}
+
+{% endmacro %}
+
+
+{#
+    Macro: impute_with_median
+    Description: Replace null values with the median of the column.
+
+    Alteryx Equivalent: Imputation tool (median mode)
+
+    Arguments:
+        relation: Source relation
+        column: Column to impute
+        group_by: Optional columns for grouped imputation
+
+    Example Usage:
+        {{ impute_with_median(ref('stg_orders'), 'order_amount') }}
+#}
+
+{% macro impute_with_median(relation, column, group_by=none) %}
+
+{% if group_by %}
+with median_values as (
+    select
+        {{ group_by | join(', ') }},
+        approx_percentile({{ column }}, 0.5) as _impute_value
+    from {{ relation }}
+    where {{ column }} is not null
+    group by {{ group_by | join(', ') }}
+)
+
+select
+    {%- set all_columns = adapter.get_columns_in_relation(relation) %}
+    {%- for col in all_columns %}
+        {%- if col.name == column %}
+    coalesce(t.{{ column }}, m._impute_value) as {{ column }}
+        {%- else %}
+    t.{{ col.name }}
+        {%- endif %}
+        {%- if not loop.last %},{% endif %}
+    {%- endfor %}
+from {{ relation }} t
+left join median_values m on
+    {%- for gc in group_by %}
+    t.{{ gc }} = m.{{ gc }}{% if not loop.last %} and {% endif %}
+    {%- endfor %}
+{% else %}
+select
+    {%- set all_columns = adapter.get_columns_in_relation(relation) %}
+    {%- for col in all_columns %}
+        {%- if col.name == column %}
+    coalesce({{ column }}, (select approx_percentile({{ column }}, 0.5) from {{ relation }} where {{ column }} is not null)) as {{ column }}
+        {%- else %}
+    {{ col.name }}
+        {%- endif %}
+        {%- if not loop.last %},{% endif %}
+    {%- endfor %}
+from {{ relation }}
+{% endif %}
+
+{% endmacro %}
+
+
+{#
+    Macro: impute_with_mode
+    Description: Replace null values with the most frequent value.
+
+    Alteryx Equivalent: Imputation tool (mode)
+
+    Arguments:
+        relation: Source relation
+        column: Column to impute
+        group_by: Optional columns for grouped imputation
+
+    Example Usage:
+        {{ impute_with_mode(ref('stg_customers'), 'country') }}
+#}
+
+{% macro impute_with_mode(relation, column, group_by=none) %}
+
+{% if group_by %}
+with mode_values as (
+    select
+        {{ group_by | join(', ') }},
+        {{ column }} as _impute_value,
+        row_number() over (partition by {{ group_by | join(', ') }} order by count(*) desc) as _rn
+    from {{ relation }}
+    where {{ column }} is not null
+    group by {{ group_by | join(', ') }}, {{ column }}
+)
+
+select
+    {%- set all_columns = adapter.get_columns_in_relation(relation) %}
+    {%- for col in all_columns %}
+        {%- if col.name == column %}
+    coalesce(t.{{ column }}, m._impute_value) as {{ column }}
+        {%- else %}
+    t.{{ col.name }}
+        {%- endif %}
+        {%- if not loop.last %},{% endif %}
+    {%- endfor %}
+from {{ relation }} t
+left join mode_values m on
+    {%- for gc in group_by %}
+    t.{{ gc }} = m.{{ gc }}{% if not loop.last %} and {% endif %}
+    {%- endfor %}
+    and m._rn = 1
+{% else %}
+with mode_value as (
+    select {{ column }} as _impute_value
+    from {{ relation }}
+    where {{ column }} is not null
+    group by {{ column }}
+    order by count(*) desc
+    limit 1
+)
+
+select
+    {%- set all_columns = adapter.get_columns_in_relation(relation) %}
+    {%- for col in all_columns %}
+        {%- if col.name == column %}
+    coalesce(t.{{ column }}, m._impute_value) as {{ column }}
+        {%- else %}
+    t.{{ col.name }}
+        {%- endif %}
+        {%- if not loop.last %},{% endif %}
+    {%- endfor %}
+from {{ relation }} t
+cross join mode_value m
+{% endif %}
+
+{% endmacro %}
+
+
+{#
+    Macro: impute_forward_fill
+    Description: Fill null values with the previous non-null value (LOCF).
+
+    Alteryx Equivalent: Multi-Row Formula for forward fill
+
+    Arguments:
+        relation: Source relation
+        column: Column to impute
+        order_by: Columns to order by (determines "previous")
+        partition_by: Optional partition columns
+
+    Example Usage:
+        {{ impute_forward_fill(
+            relation=ref('stg_timeseries'),
+            column='value',
+            order_by=['date'],
+            partition_by=['product_id']
+        ) }}
+#}
+
+{% macro impute_forward_fill(relation, column, order_by, partition_by=none) %}
+
+select
+    {%- set all_columns = adapter.get_columns_in_relation(relation) %}
+    {%- for col in all_columns %}
+        {%- if col.name == column %}
+    coalesce(
+        {{ column }},
+        last_value({{ column }}) ignore nulls over (
+            {% if partition_by %}partition by {{ partition_by | join(', ') }}{% endif %}
+            order by {{ order_by | join(', ') }}
+            rows between unbounded preceding and 1 preceding
+        )
+    ) as {{ column }}
+        {%- else %}
+    {{ col.name }}
+        {%- endif %}
+        {%- if not loop.last %},{% endif %}
+    {%- endfor %}
+from {{ relation }}
+
+{% endmacro %}
+
+
+{#
+    Macro: impute_backward_fill
+    Description: Fill null values with the next non-null value.
+
+    Alteryx Equivalent: Multi-Row Formula for backward fill
+
+    Arguments:
+        relation: Source relation
+        column: Column to impute
+        order_by: Columns to order by
+        partition_by: Optional partition columns
+
+    Example Usage:
+        {{ impute_backward_fill(ref('stg_data'), 'price', ['date']) }}
+#}
+
+{% macro impute_backward_fill(relation, column, order_by, partition_by=none) %}
+
+select
+    {%- set all_columns = adapter.get_columns_in_relation(relation) %}
+    {%- for col in all_columns %}
+        {%- if col.name == column %}
+    coalesce(
+        {{ column }},
+        first_value({{ column }}) ignore nulls over (
+            {% if partition_by %}partition by {{ partition_by | join(', ') }}{% endif %}
+            order by {{ order_by | join(', ') }}
+            rows between 1 following and unbounded following
+        )
+    ) as {{ column }}
+        {%- else %}
+    {{ col.name }}
+        {%- endif %}
+        {%- if not loop.last %},{% endif %}
+    {%- endfor %}
+from {{ relation }}
+
+{% endmacro %}
+
+
+{#
+    Macro: impute_linear_interpolation
+    Description: Linear interpolation for missing numeric values.
+
+    Alteryx Equivalent: Custom formula for interpolation
+
+    Arguments:
+        relation: Source relation
+        value_column: Column to interpolate
+        order_column: Column defining order (usually date/time)
+        partition_by: Optional partition columns
+
+    Example Usage:
+        {{ impute_linear_interpolation(
+            relation=ref('stg_metrics'),
+            value_column='measurement',
+            order_column='timestamp'
+        ) }}
+#}
+
+{% macro impute_linear_interpolation(relation, value_column, order_column, partition_by=none) %}
+
+with with_neighbors as (
+    select
+        *,
+        last_value({{ value_column }}) ignore nulls over (
+            {% if partition_by %}partition by {{ partition_by | join(', ') }}{% endif %}
+            order by {{ order_column }}
+            rows between unbounded preceding and 1 preceding
+        ) as _prev_value,
+        last_value({{ order_column }}) ignore nulls over (
+            {% if partition_by %}partition by {{ partition_by | join(', ') }}{% endif %}
+            order by {{ order_column }}
+            rows between unbounded preceding and 1 preceding
+        ) as _prev_order,
+        first_value({{ value_column }}) ignore nulls over (
+            {% if partition_by %}partition by {{ partition_by | join(', ') }}{% endif %}
+            order by {{ order_column }}
+            rows between 1 following and unbounded following
+        ) as _next_value,
+        first_value({{ order_column }}) ignore nulls over (
+            {% if partition_by %}partition by {{ partition_by | join(', ') }}{% endif %}
+            order by {{ order_column }}
+            rows between 1 following and unbounded following
+        ) as _next_order
+    from {{ relation }}
+)
+
+select
+    {%- set all_columns = adapter.get_columns_in_relation(relation) %}
+    {%- for col in all_columns %}
+        {%- if col.name == value_column %}
+    coalesce(
+        {{ value_column }},
+        case
+            when _prev_value is not null and _next_value is not null
+            then _prev_value + (
+                (_next_value - _prev_value) *
+                (date_diff('second', _prev_order, {{ order_column }}) * 1.0 /
+                 nullif(date_diff('second', _prev_order, _next_order), 0))
+            )
+            when _prev_value is not null then _prev_value
+            when _next_value is not null then _next_value
+        end
+    ) as {{ value_column }}
+        {%- else %}
+    {{ col.name }}
+        {%- endif %}
+        {%- if not loop.last %},{% endif %}
+    {%- endfor %}
+from with_neighbors
+
+{% endmacro %}
+
+
+{#
+    Macro: impute_multiple_columns
+    Description: Apply imputation to multiple columns at once.
+
+    Alteryx Equivalent: Imputation tool with multiple fields
+
+    Arguments:
+        relation: Source relation
+        imputation_config: Dictionary of column: {method: 'mean'|'median'|'mode'|'value', value: x}
+
+    Example Usage:
+        {{ impute_multiple_columns(
+            relation=ref('stg_data'),
+            imputation_config={
+                'age': {'method': 'median'},
+                'income': {'method': 'mean'},
+                'country': {'method': 'mode'},
+                'status': {'method': 'value', 'value': "'Unknown'"}
+            }
+        ) }}
+#}
+
+{% macro impute_multiple_columns(relation, imputation_config) %}
+
+with
+{% for col, config in imputation_config.items() %}
+    {% if config.method == 'mean' %}
+_{{ col }}_stat as (
+    select avg({{ col }}) as _impute_val from {{ relation }} where {{ col }} is not null
+),
+    {% elif config.method == 'median' %}
+_{{ col }}_stat as (
+    select approx_percentile({{ col }}, 0.5) as _impute_val from {{ relation }} where {{ col }} is not null
+),
+    {% elif config.method == 'mode' %}
+_{{ col }}_stat as (
+    select {{ col }} as _impute_val
+    from {{ relation }}
+    where {{ col }} is not null
+    group by {{ col }}
+    order by count(*) desc
+    limit 1
+),
+    {% endif %}
+{% endfor %}
+_source as (select * from {{ relation }})
+
+select
+    {%- set all_columns = adapter.get_columns_in_relation(relation) %}
+    {%- for col in all_columns %}
+        {%- if col.name in imputation_config %}
+            {%- set config = imputation_config[col.name] %}
+            {%- if config.method == 'value' %}
+    coalesce({{ col.name }}, {{ config.value }}) as {{ col.name }}
+            {%- else %}
+    coalesce(t.{{ col.name }}, _{{ col.name }}_stat._impute_val) as {{ col.name }}
+            {%- endif %}
+        {%- else %}
+    t.{{ col.name }}
+        {%- endif %}
+        {%- if not loop.last %},{% endif %}
+    {%- endfor %}
+from _source t
+{% for col, config in imputation_config.items() %}
+    {% if config.method in ['mean', 'median', 'mode'] %}
+cross join _{{ col }}_stat
+    {% endif %}
+{% endfor %}
+
+{% endmacro %}

--- a/dbt_macros/join_union.sql
+++ b/dbt_macros/join_union.sql
@@ -1,0 +1,490 @@
+{#
+    =============================================================================
+    Join and Union Macros
+    Alteryx Equivalent: Join tool, Union tool, Append Fields, Join Multiple
+    Trino Compatible: Yes
+    =============================================================================
+
+    These macros provide comprehensive join and union functionality matching
+    Alteryx join tool capabilities.
+#}
+
+{#
+    Macro: inner_join
+    Description: Performs an inner join between two relations.
+
+    Alteryx Equivalent: Join tool (Inner Join)
+
+    Arguments:
+        left_relation: Left/primary relation
+        right_relation: Right relation
+        left_key: Join key column(s) from left relation
+        right_key: Join key column(s) from right relation (defaults to left_key)
+        select_left: List of columns from left (default: all)
+        select_right: List of columns from right (default: all except keys)
+
+    Example Usage:
+        {{ inner_join(
+            left_relation=ref('orders'),
+            right_relation=ref('customers'),
+            left_key=['customer_id'],
+            select_left=['order_id', 'customer_id', 'amount'],
+            select_right=['customer_name', 'email']
+        ) }}
+#}
+
+{% macro inner_join(left_relation, right_relation, left_key, right_key=none, select_left=none, select_right=none) %}
+
+{%- set rkey = right_key if right_key else left_key -%}
+{%- set lkey_list = left_key if left_key is iterable and left_key is not string else [left_key] -%}
+{%- set rkey_list = rkey if rkey is iterable and rkey is not string else [rkey] -%}
+
+select
+    {%- if select_left %}
+    {%- for col in select_left %}
+    l.{{ col }},
+    {%- endfor %}
+    {%- else %}
+    l.*,
+    {%- endif %}
+    {%- if select_right %}
+    {%- for col in select_right %}
+    r.{{ col }}{% if not loop.last %},{% endif %}
+    {%- endfor %}
+    {%- else %}
+    r.*
+    {%- endif %}
+from {{ left_relation }} l
+inner join {{ right_relation }} r
+    on {% for i in range(lkey_list | length) %}
+    l.{{ lkey_list[i] }} = r.{{ rkey_list[i] }}{% if not loop.last %} and {% endif %}
+    {%- endfor %}
+
+{% endmacro %}
+
+
+{#
+    Macro: left_join
+    Description: Performs a left outer join.
+
+    Alteryx Equivalent: Join tool (Left Outer Join)
+
+    Arguments:
+        left_relation: Left/primary relation
+        right_relation: Right relation
+        left_key: Join key(s) from left
+        right_key: Join key(s) from right
+        select_left: Columns from left
+        select_right: Columns from right
+
+    Example Usage:
+        {{ left_join(
+            left_relation=ref('orders'),
+            right_relation=ref('customers'),
+            left_key='customer_id'
+        ) }}
+#}
+
+{% macro left_join(left_relation, right_relation, left_key, right_key=none, select_left=none, select_right=none) %}
+
+{%- set rkey = right_key if right_key else left_key -%}
+{%- set lkey_list = left_key if left_key is iterable and left_key is not string else [left_key] -%}
+{%- set rkey_list = rkey if rkey is iterable and rkey is not string else [rkey] -%}
+
+select
+    {%- if select_left %}
+    {%- for col in select_left %}
+    l.{{ col }},
+    {%- endfor %}
+    {%- else %}
+    l.*,
+    {%- endif %}
+    {%- if select_right %}
+    {%- for col in select_right %}
+    r.{{ col }}{% if not loop.last %},{% endif %}
+    {%- endfor %}
+    {%- else %}
+    r.*
+    {%- endif %}
+from {{ left_relation }} l
+left join {{ right_relation }} r
+    on {% for i in range(lkey_list | length) %}
+    l.{{ lkey_list[i] }} = r.{{ rkey_list[i] }}{% if not loop.last %} and {% endif %}
+    {%- endfor %}
+
+{% endmacro %}
+
+
+{#
+    Macro: right_join
+    Description: Performs a right outer join.
+
+    Alteryx Equivalent: Join tool (Right Outer Join)
+
+    Arguments:
+        Same as left_join
+
+    Example Usage:
+        {{ right_join(ref('orders'), ref('customers'), 'customer_id') }}
+#}
+
+{% macro right_join(left_relation, right_relation, left_key, right_key=none, select_left=none, select_right=none) %}
+
+{%- set rkey = right_key if right_key else left_key -%}
+{%- set lkey_list = left_key if left_key is iterable and left_key is not string else [left_key] -%}
+{%- set rkey_list = rkey if rkey is iterable and rkey is not string else [rkey] -%}
+
+select
+    {%- if select_left %}
+    {%- for col in select_left %}
+    l.{{ col }},
+    {%- endfor %}
+    {%- else %}
+    l.*,
+    {%- endif %}
+    {%- if select_right %}
+    {%- for col in select_right %}
+    r.{{ col }}{% if not loop.last %},{% endif %}
+    {%- endfor %}
+    {%- else %}
+    r.*
+    {%- endif %}
+from {{ left_relation }} l
+right join {{ right_relation }} r
+    on {% for i in range(lkey_list | length) %}
+    l.{{ lkey_list[i] }} = r.{{ rkey_list[i] }}{% if not loop.last %} and {% endif %}
+    {%- endfor %}
+
+{% endmacro %}
+
+
+{#
+    Macro: full_outer_join
+    Description: Performs a full outer join.
+
+    Alteryx Equivalent: Join tool (Full Outer Join)
+
+    Arguments:
+        Same as other joins
+
+    Example Usage:
+        {{ full_outer_join(ref('table_a'), ref('table_b'), 'id') }}
+#}
+
+{% macro full_outer_join(left_relation, right_relation, left_key, right_key=none, select_left=none, select_right=none) %}
+
+{%- set rkey = right_key if right_key else left_key -%}
+{%- set lkey_list = left_key if left_key is iterable and left_key is not string else [left_key] -%}
+{%- set rkey_list = rkey if rkey is iterable and rkey is not string else [rkey] -%}
+
+select
+    {%- if select_left %}
+    {%- for col in select_left %}
+    l.{{ col }},
+    {%- endfor %}
+    {%- else %}
+    l.*,
+    {%- endif %}
+    {%- if select_right %}
+    {%- for col in select_right %}
+    r.{{ col }}{% if not loop.last %},{% endif %}
+    {%- endfor %}
+    {%- else %}
+    r.*
+    {%- endif %}
+from {{ left_relation }} l
+full outer join {{ right_relation }} r
+    on {% for i in range(lkey_list | length) %}
+    l.{{ lkey_list[i] }} = r.{{ rkey_list[i] }}{% if not loop.last %} and {% endif %}
+    {%- endfor %}
+
+{% endmacro %}
+
+
+{#
+    Macro: cross_join
+    Description: Performs a cross join (cartesian product).
+
+    Alteryx Equivalent: Append Fields tool
+
+    Arguments:
+        left_relation: Left relation
+        right_relation: Right relation
+
+    Example Usage:
+        {{ cross_join(ref('dates'), ref('products')) }}
+#}
+
+{% macro cross_join(left_relation, right_relation) %}
+
+select
+    l.*,
+    r.*
+from {{ left_relation }} l
+cross join {{ right_relation }} r
+
+{% endmacro %}
+
+
+{#
+    Macro: anti_join
+    Description: Returns left rows that have no match in right (Left Only).
+
+    Alteryx Equivalent: Join tool L output (non-matching from left)
+
+    Arguments:
+        left_relation: Left relation
+        right_relation: Right relation
+        left_key: Join key(s) from left
+        right_key: Join key(s) from right
+
+    Example Usage:
+        {{ anti_join(ref('all_customers'), ref('active_orders'), 'customer_id') }}
+#}
+
+{% macro anti_join(left_relation, right_relation, left_key, right_key=none) %}
+
+{%- set rkey = right_key if right_key else left_key -%}
+{%- set lkey_list = left_key if left_key is iterable and left_key is not string else [left_key] -%}
+{%- set rkey_list = rkey if rkey is iterable and rkey is not string else [rkey] -%}
+
+select l.*
+from {{ left_relation }} l
+left join {{ right_relation }} r
+    on {% for i in range(lkey_list | length) %}
+    l.{{ lkey_list[i] }} = r.{{ rkey_list[i] }}{% if not loop.last %} and {% endif %}
+    {%- endfor %}
+where r.{{ rkey_list[0] }} is null
+
+{% endmacro %}
+
+
+{#
+    Macro: semi_join
+    Description: Returns left rows that have a match in right (exists check).
+
+    Alteryx Equivalent: Join tool J output selecting only left columns
+
+    Arguments:
+        left_relation: Left relation
+        right_relation: Right relation
+        left_key: Join key(s) from left
+        right_key: Join key(s) from right
+
+    Example Usage:
+        {{ semi_join(ref('products'), ref('order_items'), 'product_id') }}
+#}
+
+{% macro semi_join(left_relation, right_relation, left_key, right_key=none) %}
+
+{%- set rkey = right_key if right_key else left_key -%}
+{%- set lkey_list = left_key if left_key is iterable and left_key is not string else [left_key] -%}
+{%- set rkey_list = rkey if rkey is iterable and rkey is not string else [rkey] -%}
+
+select l.*
+from {{ left_relation }} l
+where exists (
+    select 1
+    from {{ right_relation }} r
+    where {% for i in range(lkey_list | length) %}
+    l.{{ lkey_list[i] }} = r.{{ rkey_list[i] }}{% if not loop.last %} and {% endif %}
+    {%- endfor %}
+)
+
+{% endmacro %}
+
+
+{#
+    Macro: union_all
+    Description: Stacks datasets vertically (keeps duplicates).
+
+    Alteryx Equivalent: Union tool (default mode)
+
+    Arguments:
+        relations: List of relations to union
+
+    Example Usage:
+        {{ union_all([ref('sales_2022'), ref('sales_2023'), ref('sales_2024')]) }}
+#}
+
+{% macro union_all(relations) %}
+
+{%- for relation in relations %}
+select * from {{ relation }}
+{% if not loop.last %}union all{% endif %}
+{%- endfor %}
+
+{% endmacro %}
+
+
+{#
+    Macro: union_distinct
+    Description: Stacks datasets vertically with duplicate removal.
+
+    Alteryx Equivalent: Union tool with Auto-config by name + Unique
+
+    Arguments:
+        relations: List of relations to union
+
+    Example Usage:
+        {{ union_distinct([ref('source_a'), ref('source_b')]) }}
+#}
+
+{% macro union_distinct(relations) %}
+
+{%- for relation in relations %}
+select * from {{ relation }}
+{% if not loop.last %}union{% endif %}
+{%- endfor %}
+
+{% endmacro %}
+
+
+{#
+    Macro: union_with_source
+    Description: Union with source identifier column.
+
+    Alteryx Equivalent: Union tool + source tracking
+
+    Arguments:
+        relations: Dictionary of source_name: relation pairs
+
+    Example Usage:
+        {{ union_with_source({
+            'web': ref('web_orders'),
+            'mobile': ref('mobile_orders'),
+            'store': ref('store_orders')
+        }) }}
+#}
+
+{% macro union_with_source(relations) %}
+
+{%- for source_name, relation in relations.items() %}
+select
+    '{{ source_name }}' as _source,
+    *
+from {{ relation }}
+{% if not loop.last %}union all{% endif %}
+{%- endfor %}
+
+{% endmacro %}
+
+
+{#
+    Macro: join_multiple
+    Description: Joins multiple tables together.
+
+    Alteryx Equivalent: Join Multiple tool
+
+    Arguments:
+        base_relation: Starting relation
+        joins: List of {relation: ..., key: ..., type: ...} dictionaries
+
+    Example Usage:
+        {{ join_multiple(
+            base_relation=ref('orders'),
+            joins=[
+                {'relation': ref('customers'), 'key': 'customer_id', 'type': 'left'},
+                {'relation': ref('products'), 'key': 'product_id', 'type': 'left'},
+                {'relation': ref('regions'), 'key': 'region_id', 'type': 'inner'}
+            ]
+        ) }}
+#}
+
+{% macro join_multiple(base_relation, joins) %}
+
+select
+    t0.*
+    {%- for i in range(joins | length) %},
+    t{{ i + 1 }}.*
+    {%- endfor %}
+from {{ base_relation }} t0
+{%- for i, join_spec in enumerate(joins) %}
+{{ join_spec.get('type', 'left') }} join {{ join_spec.relation }} t{{ i + 1 }}
+    on t0.{{ join_spec.key }} = t{{ i + 1 }}.{{ join_spec.key }}
+{%- endfor %}
+
+{% endmacro %}
+
+
+{#
+    Macro: except_rows
+    Description: Returns rows in first relation not in second.
+
+    Alteryx Equivalent: Unique tool comparing two inputs
+
+    Arguments:
+        relation_a: First relation
+        relation_b: Second relation (rows to exclude)
+
+    Example Usage:
+        {{ except_rows(ref('all_products'), ref('discontinued_products')) }}
+#}
+
+{% macro except_rows(relation_a, relation_b) %}
+
+select * from {{ relation_a }}
+except
+select * from {{ relation_b }}
+
+{% endmacro %}
+
+
+{#
+    Macro: intersect_rows
+    Description: Returns rows present in both relations.
+
+    Alteryx Equivalent: Join to find matching records
+
+    Arguments:
+        relation_a: First relation
+        relation_b: Second relation
+
+    Example Usage:
+        {{ intersect_rows(ref('customers_2023'), ref('customers_2024')) }}
+#}
+
+{% macro intersect_rows(relation_a, relation_b) %}
+
+select * from {{ relation_a }}
+intersect
+select * from {{ relation_b }}
+
+{% endmacro %}
+
+
+{#
+    Macro: lookup_join
+    Description: Enriches data by looking up values from a reference table.
+
+    Alteryx Equivalent: Find Replace / Join for lookup
+
+    Arguments:
+        fact_relation: Main/fact relation
+        lookup_relation: Lookup/dimension relation
+        fact_key: Key column in fact
+        lookup_key: Key column in lookup
+        lookup_columns: Columns to add from lookup
+
+    Example Usage:
+        {{ lookup_join(
+            fact_relation=ref('orders'),
+            lookup_relation=ref('dim_products'),
+            fact_key='product_id',
+            lookup_key='product_id',
+            lookup_columns=['product_name', 'category', 'unit_price']
+        ) }}
+#}
+
+{% macro lookup_join(fact_relation, lookup_relation, fact_key, lookup_key, lookup_columns) %}
+
+select
+    f.*,
+    {%- for col in lookup_columns %}
+    l.{{ col }}{% if not loop.last %},{% endif %}
+    {%- endfor %}
+from {{ fact_relation }} f
+left join {{ lookup_relation }} l
+    on f.{{ fact_key }} = l.{{ lookup_key }}
+
+{% endmacro %}

--- a/dbt_macros/math_functions.sql
+++ b/dbt_macros/math_functions.sql
@@ -1,0 +1,463 @@
+{#
+    =============================================================================
+    Math Functions Macros
+    Alteryx Equivalent: Formula tool with math functions
+    Trino Compatible: Yes
+    =============================================================================
+
+    These macros provide mathematical function helpers matching Alteryx
+    formula tool math capabilities.
+#}
+
+{#
+    Macro: abs_value
+    Description: Returns absolute value.
+
+    Alteryx Equivalent: Abs([field])
+
+    Arguments:
+        column: Column or expression
+
+    Example Usage:
+        {{ abs_value('profit_loss') }} as absolute_value
+#}
+
+{% macro abs_value(column) %}
+abs({{ column }})
+{% endmacro %}
+
+
+{#
+    Macro: round_value
+    Description: Rounds a number to specified decimal places.
+
+    Alteryx Equivalent: Round([field], decimals)
+
+    Arguments:
+        column: Column or expression to round
+        decimals: Number of decimal places (default: 0)
+
+    Example Usage:
+        {{ round_value('price', 2) }} as rounded_price
+#}
+
+{% macro round_value(column, decimals=0) %}
+round({{ column }}, {{ decimals }})
+{% endmacro %}
+
+
+{#
+    Macro: ceil_value
+    Description: Rounds up to nearest integer.
+
+    Alteryx Equivalent: Ceil([field])
+
+    Arguments:
+        column: Column or expression
+
+    Example Usage:
+        {{ ceil_value('quantity / units_per_box') }} as boxes_needed
+#}
+
+{% macro ceil_value(column) %}
+ceil({{ column }})
+{% endmacro %}
+
+
+{#
+    Macro: floor_value
+    Description: Rounds down to nearest integer.
+
+    Alteryx Equivalent: Floor([field])
+
+    Arguments:
+        column: Column or expression
+
+    Example Usage:
+        {{ floor_value('total / page_size') }} as full_pages
+#}
+
+{% macro floor_value(column) %}
+floor({{ column }})
+{% endmacro %}
+
+
+{#
+    Macro: truncate_value
+    Description: Truncates a number to specified decimal places.
+
+    Alteryx Equivalent: Truncate equivalent
+
+    Arguments:
+        column: Column or expression
+        decimals: Number of decimal places (default: 0)
+
+    Example Usage:
+        {{ truncate_value('amount', 2) }} as truncated_amount
+#}
+
+{% macro truncate_value(column, decimals=0) %}
+truncate({{ column }} * power(10, {{ decimals }})) / power(10, {{ decimals }})
+{% endmacro %}
+
+
+{#
+    Macro: power_value
+    Description: Raises a number to a power.
+
+    Alteryx Equivalent: Pow([base], [exponent])
+
+    Arguments:
+        base: Base value
+        exponent: Exponent value
+
+    Example Usage:
+        {{ power_value('2', 10) }} as two_to_tenth
+#}
+
+{% macro power_value(base, exponent) %}
+power({{ base }}, {{ exponent }})
+{% endmacro %}
+
+
+{#
+    Macro: sqrt_value
+    Description: Calculates square root.
+
+    Alteryx Equivalent: Sqrt([field])
+
+    Arguments:
+        column: Column or expression
+
+    Example Usage:
+        {{ sqrt_value('variance') }} as std_dev
+#}
+
+{% macro sqrt_value(column) %}
+sqrt({{ column }})
+{% endmacro %}
+
+
+{#
+    Macro: log_value
+    Description: Calculates logarithm.
+
+    Alteryx Equivalent: Log([field]) or Log10([field])
+
+    Arguments:
+        column: Column or expression
+        base: Logarithm base ('natural', '10', '2', or numeric)
+
+    Example Usage:
+        {{ log_value('population', 'natural') }} as ln_population
+        {{ log_value('value', 10) }} as log10_value
+#}
+
+{% macro log_value(column, base='natural') %}
+{% if base == 'natural' %}
+ln({{ column }})
+{% elif base == 10 or base == '10' %}
+log10({{ column }})
+{% elif base == 2 or base == '2' %}
+log2({{ column }})
+{% else %}
+log({{ base }}, {{ column }})
+{% endif %}
+{% endmacro %}
+
+
+{#
+    Macro: exp_value
+    Description: Calculates e raised to a power.
+
+    Alteryx Equivalent: Exp([field])
+
+    Arguments:
+        column: Column or expression (the exponent)
+
+    Example Usage:
+        {{ exp_value('growth_rate') }} as exponential_growth
+#}
+
+{% macro exp_value(column) %}
+exp({{ column }})
+{% endmacro %}
+
+
+{#
+    Macro: mod_value
+    Description: Calculates modulo (remainder).
+
+    Alteryx Equivalent: Mod([dividend], [divisor])
+
+    Arguments:
+        dividend: The number to divide
+        divisor: The number to divide by
+
+    Example Usage:
+        {{ mod_value('row_num', 10) }} as batch_position
+#}
+
+{% macro mod_value(dividend, divisor) %}
+mod({{ dividend }}, {{ divisor }})
+{% endmacro %}
+
+
+{#
+    Macro: sign_value
+    Description: Returns the sign of a number (-1, 0, or 1).
+
+    Alteryx Equivalent: Sign([field])
+
+    Arguments:
+        column: Column or expression
+
+    Example Usage:
+        {{ sign_value('balance') }} as balance_direction
+#}
+
+{% macro sign_value(column) %}
+sign({{ column }})
+{% endmacro %}
+
+
+{#
+    Macro: rand_value
+    Description: Generates a random number.
+
+    Alteryx Equivalent: Rand()
+
+    Arguments:
+        min_val: Minimum value (default: 0)
+        max_val: Maximum value (default: 1)
+
+    Example Usage:
+        {{ rand_value(1, 100) }} as random_1_to_100
+#}
+
+{% macro rand_value(min_val=0, max_val=1) %}
+{% if min_val == 0 and max_val == 1 %}
+random()
+{% else %}
+random() * ({{ max_val }} - {{ min_val }}) + {{ min_val }}
+{% endif %}
+{% endmacro %}
+
+
+{#
+    Macro: rand_int
+    Description: Generates a random integer.
+
+    Alteryx Equivalent: RandInt([min], [max])
+
+    Arguments:
+        min_val: Minimum value (inclusive)
+        max_val: Maximum value (inclusive)
+
+    Example Usage:
+        {{ rand_int(1, 6) }} as dice_roll
+#}
+
+{% macro rand_int(min_val, max_val) %}
+floor(random() * ({{ max_val }} - {{ min_val }} + 1)) + {{ min_val }}
+{% endmacro %}
+
+
+{#
+    Macro: safe_divide
+    Description: Division that returns null or default on divide by zero.
+
+    Alteryx Equivalent: IIF([divisor] = 0, 0, [dividend] / [divisor])
+
+    Arguments:
+        dividend: The number to divide
+        divisor: The number to divide by
+        default: Value when dividing by zero (default: null)
+
+    Example Usage:
+        {{ safe_divide('total_revenue', 'transaction_count', 0) }} as avg_transaction
+#}
+
+{% macro safe_divide(dividend, divisor, default=none) %}
+{% if default is not none %}
+coalesce({{ dividend }} / nullif({{ divisor }}, 0), {{ default }})
+{% else %}
+{{ dividend }} / nullif({{ divisor }}, 0)
+{% endif %}
+{% endmacro %}
+
+
+{#
+    Macro: percentage
+    Description: Calculates percentage.
+
+    Alteryx Equivalent: Formula for percentage calculation
+
+    Arguments:
+        part: The part value
+        whole: The whole value
+        decimals: Decimal places in result (default: 2)
+        multiply_100: Whether to multiply by 100 (default: true)
+
+    Example Usage:
+        {{ percentage('completed_tasks', 'total_tasks') }} as completion_pct
+#}
+
+{% macro percentage(part, whole, decimals=2, multiply_100=true) %}
+round(
+    {{ part }} * 1.0 / nullif({{ whole }}, 0){% if multiply_100 %} * 100{% endif %},
+    {{ decimals }}
+)
+{% endmacro %}
+
+
+{#
+    Macro: growth_rate
+    Description: Calculates growth rate between two values.
+
+    Alteryx Equivalent: Formula for growth calculation
+
+    Arguments:
+        current_value: Current period value
+        previous_value: Previous period value
+        as_percentage: Return as percentage (default: true)
+        decimals: Decimal places (default: 2)
+
+    Example Usage:
+        {{ growth_rate('current_revenue', 'previous_revenue') }} as revenue_growth
+#}
+
+{% macro growth_rate(current_value, previous_value, as_percentage=true, decimals=2) %}
+round(
+    ({{ current_value }} - {{ previous_value }}) / nullif(abs({{ previous_value }}), 0)
+    {% if as_percentage %} * 100{% endif %},
+    {{ decimals }}
+)
+{% endmacro %}
+
+
+{#
+    Macro: min_max_normalize
+    Description: Normalizes values to 0-1 range using min-max scaling.
+
+    Alteryx Equivalent: Formula for normalization
+
+    Arguments:
+        column: Column to normalize
+        min_expr: Expression for minimum (or literal)
+        max_expr: Expression for maximum (or literal)
+
+    Example Usage:
+        select {{ min_max_normalize('score', 'min(score) over ()', 'max(score) over ()') }} as normalized_score
+#}
+
+{% macro min_max_normalize(column, min_expr, max_expr) %}
+({{ column }} - ({{ min_expr }})) / nullif(({{ max_expr }}) - ({{ min_expr }}), 0)
+{% endmacro %}
+
+
+{#
+    Macro: z_score
+    Description: Calculates z-score (standard score).
+
+    Alteryx Equivalent: Formula for standardization
+
+    Arguments:
+        column: Column to standardize
+        mean_expr: Expression for mean
+        stddev_expr: Expression for standard deviation
+
+    Example Usage:
+        select {{ z_score('value', 'avg(value) over ()', 'stddev(value) over ()') }} as z_score
+#}
+
+{% macro z_score(column, mean_expr, stddev_expr) %}
+({{ column }} - ({{ mean_expr }})) / nullif(({{ stddev_expr }}), 0)
+{% endmacro %}
+
+
+{#
+    Macro: clamp_value
+    Description: Clamps a value between min and max bounds.
+
+    Alteryx Equivalent: IIF([value] < min, min, IIF([value] > max, max, [value]))
+
+    Arguments:
+        column: Column to clamp
+        min_val: Minimum allowed value
+        max_val: Maximum allowed value
+
+    Example Usage:
+        {{ clamp_value('score', 0, 100) }} as clamped_score
+#}
+
+{% macro clamp_value(column, min_val, max_val) %}
+greatest(least({{ column }}, {{ max_val }}), {{ min_val }})
+{% endmacro %}
+
+
+{#
+    Macro: trig_function
+    Description: Trigonometric functions.
+
+    Alteryx Equivalent: Sin(), Cos(), Tan(), etc.
+
+    Arguments:
+        column: Column or expression (in radians)
+        func: 'sin', 'cos', 'tan', 'asin', 'acos', 'atan'
+
+    Example Usage:
+        {{ trig_function('angle_radians', 'sin') }} as sine_value
+#}
+
+{% macro trig_function(column, func='sin') %}
+{% if func == 'sin' %}
+sin({{ column }})
+{% elif func == 'cos' %}
+cos({{ column }})
+{% elif func == 'tan' %}
+tan({{ column }})
+{% elif func == 'asin' %}
+asin({{ column }})
+{% elif func == 'acos' %}
+acos({{ column }})
+{% elif func == 'atan' %}
+atan({{ column }})
+{% else %}
+{{ column }}
+{% endif %}
+{% endmacro %}
+
+
+{#
+    Macro: degrees_to_radians
+    Description: Converts degrees to radians.
+
+    Alteryx Equivalent: Formula with PI conversion
+
+    Arguments:
+        column: Column in degrees
+
+    Example Usage:
+        {{ degrees_to_radians('angle_degrees') }} as angle_radians
+#}
+
+{% macro degrees_to_radians(column) %}
+({{ column }} * pi() / 180)
+{% endmacro %}
+
+
+{#
+    Macro: radians_to_degrees
+    Description: Converts radians to degrees.
+
+    Arguments:
+        column: Column in radians
+
+    Example Usage:
+        {{ radians_to_degrees('angle_radians') }} as angle_degrees
+#}
+
+{% macro radians_to_degrees(column) %}
+({{ column }} * 180 / pi())
+{% endmacro %}

--- a/dbt_macros/regex_functions.sql
+++ b/dbt_macros/regex_functions.sql
@@ -1,0 +1,373 @@
+{#
+    =============================================================================
+    Regex Functions Macros
+    Alteryx Equivalent: RegEx tool
+    Trino Compatible: Yes
+    =============================================================================
+
+    These macros provide regular expression functionality matching Alteryx
+    RegEx tool capabilities.
+#}
+
+{#
+    Macro: regex_match
+    Description: Returns true if pattern matches.
+
+    Alteryx Equivalent: REGEX_Match([field], pattern)
+
+    Arguments:
+        column: Column to test
+        pattern: Regular expression pattern
+
+    Example Usage:
+        where {{ regex_match('email', '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$') }}
+#}
+
+{% macro regex_match(column, pattern) %}
+regexp_like({{ column }}, '{{ pattern }}')
+{% endmacro %}
+
+
+{#
+    Macro: regex_extract
+    Description: Extracts text matching a pattern.
+
+    Alteryx Equivalent: REGEX_Replace with capture groups
+
+    Arguments:
+        column: Column to extract from
+        pattern: Regular expression pattern
+        group: Capture group to extract (default: 0 = entire match)
+
+    Example Usage:
+        {{ regex_extract('url', 'https?://([^/]+)', 1) }} as domain
+#}
+
+{% macro regex_extract(column, pattern, group=0) %}
+regexp_extract({{ column }}, '{{ pattern }}', {{ group }})
+{% endmacro %}
+
+
+{#
+    Macro: regex_extract_all
+    Description: Extracts all occurrences matching a pattern.
+
+    Alteryx Equivalent: RegEx tool with tokenize mode
+
+    Arguments:
+        column: Column to extract from
+        pattern: Regular expression pattern
+        group: Capture group (default: 0)
+
+    Example Usage:
+        {{ regex_extract_all('text', '\\b[A-Z]{2,}\\b') }} as all_acronyms
+#}
+
+{% macro regex_extract_all(column, pattern, group=0) %}
+regexp_extract_all({{ column }}, '{{ pattern }}', {{ group }})
+{% endmacro %}
+
+
+{#
+    Macro: regex_replace
+    Description: Replaces text matching pattern.
+
+    Alteryx Equivalent: REGEX_Replace([field], pattern, replacement)
+
+    Arguments:
+        column: Column to perform replacement on
+        pattern: Regular expression pattern
+        replacement: Replacement string (can use $1, $2 for groups)
+
+    Example Usage:
+        {{ regex_replace('phone', '[^0-9]', '') }} as phone_digits_only
+#}
+
+{% macro regex_replace(column, pattern, replacement='') %}
+regexp_replace({{ column }}, '{{ pattern }}', '{{ replacement }}')
+{% endmacro %}
+
+
+{#
+    Macro: regex_count
+    Description: Counts matches of a pattern.
+
+    Alteryx Equivalent: REGEX_CountMatches
+
+    Arguments:
+        column: Column to search
+        pattern: Regular expression pattern
+
+    Example Usage:
+        {{ regex_count('text', '\\bword\\b') }} as word_occurrences
+#}
+
+{% macro regex_count(column, pattern) %}
+cardinality(regexp_extract_all({{ column }}, '{{ pattern }}'))
+{% endmacro %}
+
+
+{#
+    Macro: regex_split
+    Description: Splits a string by regex pattern into an array.
+
+    Alteryx Equivalent: Text to Columns with regex delimiter
+
+    Arguments:
+        column: Column to split
+        pattern: Regex pattern to split on
+
+    Example Usage:
+        {{ regex_split('tags', ',\\s*') }} as tag_array
+#}
+
+{% macro regex_split(column, pattern) %}
+regexp_split({{ column }}, '{{ pattern }}')
+{% endmacro %}
+
+
+{#
+    Macro: extract_numbers
+    Description: Extracts all numeric characters from a string.
+
+    Alteryx Equivalent: REGEX_Replace([field], '[^0-9]', '')
+
+    Arguments:
+        column: Column to extract numbers from
+
+    Example Usage:
+        {{ extract_numbers('mixed_text') }} as numbers_only
+#}
+
+{% macro extract_numbers(column) %}
+regexp_replace({{ column }}, '[^0-9]', '')
+{% endmacro %}
+
+
+{#
+    Macro: extract_first_number
+    Description: Extracts the first number from a string.
+
+    Alteryx Equivalent: REGEX_Match pattern for first number
+
+    Arguments:
+        column: Column to extract from
+        include_decimals: Include decimal numbers (default: true)
+        include_negative: Include negative numbers (default: true)
+
+    Example Usage:
+        {{ extract_first_number('price_text') }} as price_value
+#}
+
+{% macro extract_first_number(column, include_decimals=true, include_negative=true) %}
+{% if include_negative and include_decimals %}
+try_cast(regexp_extract({{ column }}, '-?[0-9]+\\.?[0-9]*') as double)
+{% elif include_decimals %}
+try_cast(regexp_extract({{ column }}, '[0-9]+\\.?[0-9]*') as double)
+{% elif include_negative %}
+try_cast(regexp_extract({{ column }}, '-?[0-9]+') as bigint)
+{% else %}
+try_cast(regexp_extract({{ column }}, '[0-9]+') as bigint)
+{% endif %}
+{% endmacro %}
+
+
+{#
+    Macro: extract_email
+    Description: Extracts email address from text.
+
+    Alteryx Equivalent: RegEx tool with email pattern
+
+    Arguments:
+        column: Column to extract email from
+
+    Example Usage:
+        {{ extract_email('contact_info') }} as email_address
+#}
+
+{% macro extract_email(column) %}
+regexp_extract({{ column }}, '[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}')
+{% endmacro %}
+
+
+{#
+    Macro: extract_phone
+    Description: Extracts phone number from text.
+
+    Alteryx Equivalent: RegEx tool with phone pattern
+
+    Arguments:
+        column: Column to extract phone from
+        format: 'raw' (just digits), 'us' (US format), 'international'
+
+    Example Usage:
+        {{ extract_phone('contact_info', 'us') }} as phone_number
+#}
+
+{% macro extract_phone(column, format='raw') %}
+{% if format == 'raw' %}
+regexp_replace(regexp_extract({{ column }}, '[0-9()\\-\\s.+]{7,}'), '[^0-9]', '')
+{% elif format == 'us' %}
+regexp_extract({{ column }}, '\\(?[0-9]{3}\\)?[\\s.-]?[0-9]{3}[\\s.-]?[0-9]{4}')
+{% else %}
+regexp_extract({{ column }}, '\\+?[0-9][0-9()\\-\\s.]{8,}[0-9]')
+{% endif %}
+{% endmacro %}
+
+
+{#
+    Macro: extract_url
+    Description: Extracts URL from text.
+
+    Alteryx Equivalent: RegEx tool with URL pattern
+
+    Arguments:
+        column: Column to extract URL from
+
+    Example Usage:
+        {{ extract_url('message') }} as url
+#}
+
+{% macro extract_url(column) %}
+regexp_extract({{ column }}, 'https?://[^\\s<>"\\{\\}|\\\\^\\[\\]`]+')
+{% endmacro %}
+
+
+{#
+    Macro: extract_domain
+    Description: Extracts domain from URL or email.
+
+    Alteryx Equivalent: RegEx tool for domain extraction
+
+    Arguments:
+        column: Column containing URL or email
+
+    Example Usage:
+        {{ extract_domain('website') }} as domain
+#}
+
+{% macro extract_domain(column) %}
+coalesce(
+    regexp_extract({{ column }}, 'https?://([^/]+)', 1),
+    regexp_extract({{ column }}, '@([a-zA-Z0-9.-]+)', 1)
+)
+{% endmacro %}
+
+
+{#
+    Macro: is_valid_email
+    Description: Returns true if value is a valid email format.
+
+    Alteryx Equivalent: RegEx validation for email
+
+    Arguments:
+        column: Column to validate
+
+    Example Usage:
+        where {{ is_valid_email('email') }}
+#}
+
+{% macro is_valid_email(column) %}
+regexp_like({{ column }}, '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$')
+{% endmacro %}
+
+
+{#
+    Macro: is_valid_phone
+    Description: Returns true if value looks like a phone number.
+
+    Alteryx Equivalent: RegEx validation for phone
+
+    Arguments:
+        column: Column to validate
+        min_digits: Minimum number of digits (default: 10)
+
+    Example Usage:
+        where {{ is_valid_phone('phone') }}
+#}
+
+{% macro is_valid_phone(column, min_digits=10) %}
+length(regexp_replace({{ column }}, '[^0-9]', '')) >= {{ min_digits }}
+{% endmacro %}
+
+
+{#
+    Macro: mask_pattern
+    Description: Masks text matching a pattern.
+
+    Alteryx Equivalent: RegEx Replace for data masking
+
+    Arguments:
+        column: Column to mask
+        pattern: Pattern to match for masking
+        mask_char: Character to use for masking (default: 'X')
+        keep_length: Preserve original length with mask (default: true)
+
+    Example Usage:
+        {{ mask_pattern('ssn', '[0-9]', 'X') }} as masked_ssn
+#}
+
+{% macro mask_pattern(column, pattern, mask_char='X', keep_length=true) %}
+{% if keep_length %}
+regexp_replace({{ column }}, '{{ pattern }}', '{{ mask_char }}')
+{% else %}
+'{{ mask_char * 5 }}'
+{% endif %}
+{% endmacro %}
+
+
+{#
+    Macro: tokenize
+    Description: Splits text into tokens/words.
+
+    Alteryx Equivalent: RegEx tool (Tokenize mode)
+
+    Arguments:
+        column: Column to tokenize
+        delimiter_pattern: Pattern for token boundaries (default: whitespace)
+
+    Example Usage:
+        {{ tokenize('description') }} as words
+#}
+
+{% macro tokenize(column, delimiter_pattern='\\s+') %}
+regexp_split({{ column }}, '{{ delimiter_pattern }}')
+{% endmacro %}
+
+
+{#
+    Macro: clean_html
+    Description: Removes HTML tags from text.
+
+    Alteryx Equivalent: RegEx Replace to strip HTML
+
+    Arguments:
+        column: Column containing HTML
+
+    Example Usage:
+        {{ clean_html('html_content') }} as plain_text
+#}
+
+{% macro clean_html(column) %}
+regexp_replace({{ column }}, '<[^>]+>', '')
+{% endmacro %}
+
+
+{#
+    Macro: parse_key_value
+    Description: Extracts value for a key from key=value format.
+
+    Alteryx Equivalent: RegEx tool for parsing
+
+    Arguments:
+        column: Column containing key=value pairs
+        key: Key to extract value for
+        delimiter: Key-value delimiter (default: '=')
+
+    Example Usage:
+        {{ parse_key_value('params', 'user_id') }} as user_id
+#}
+
+{% macro parse_key_value(column, key, delimiter='=') %}
+regexp_extract({{ column }}, '{{ key }}{{ delimiter }}([^&\\s,;]+)', 1)
+{% endmacro %}

--- a/dbt_macros/sample_limit.sql
+++ b/dbt_macros/sample_limit.sql
@@ -1,0 +1,372 @@
+{#
+    =============================================================================
+    Sample and Limit Macros
+    Alteryx Equivalent: Sample tool, Select Records tool, Random Sample
+    Trino Compatible: Yes
+    =============================================================================
+
+    These macros provide data sampling, limiting, and random sampling functionality.
+#}
+
+{#
+    Macro: sample_first_n
+    Description: Returns the first N records.
+
+    Alteryx Equivalent: Sample tool (First N records mode)
+
+    Arguments:
+        relation: The source relation
+        n: Number of records to return
+        order_by: Optional columns to order by before sampling
+
+    Example Usage:
+        {{ sample_first_n(ref('stg_orders'), 100, order_by=['order_date']) }}
+#}
+
+{% macro sample_first_n(relation, n, order_by=none) %}
+
+select *
+from {{ relation }}
+{% if order_by %}
+order by {{ order_by | join(', ') }}
+{% endif %}
+limit {{ n }}
+
+{% endmacro %}
+
+
+{#
+    Macro: sample_last_n
+    Description: Returns the last N records based on ordering.
+
+    Alteryx Equivalent: Sample tool (Last N records mode)
+
+    Arguments:
+        relation: The source relation
+        n: Number of records to return
+        order_by: Columns to order by (reversed to get last N)
+
+    Example Usage:
+        {{ sample_last_n(ref('stg_orders'), 100, order_by=['order_date']) }}
+#}
+
+{% macro sample_last_n(relation, n, order_by) %}
+
+with reversed as (
+    select
+        *,
+        row_number() over (order by {{ order_by | join(' desc, ') }} desc) as _rn
+    from {{ relation }}
+)
+
+select
+    {%- set all_columns = adapter.get_columns_in_relation(relation) %}
+    {%- for column in all_columns %}
+    {{ column.name }}{% if not loop.last %},{% endif %}
+    {%- endfor %}
+from reversed
+where _rn <= {{ n }}
+order by _rn desc
+
+{% endmacro %}
+
+
+{#
+    Macro: sample_every_nth
+    Description: Returns every Nth record.
+
+    Alteryx Equivalent: Sample tool (Every Nth record mode)
+
+    Arguments:
+        relation: The source relation
+        n: Take every Nth record
+        order_by: Optional columns to order by
+        start_offset: Start at record number (default: 1)
+
+    Example Usage:
+        {{ sample_every_nth(ref('stg_transactions'), 10, order_by=['transaction_id']) }}
+#}
+
+{% macro sample_every_nth(relation, n, order_by=none, start_offset=1) %}
+
+with numbered as (
+    select
+        *,
+        row_number() over (
+            {% if order_by %}order by {{ order_by | join(', ') }}{% else %}order by (select null){% endif %}
+        ) as _rn
+    from {{ relation }}
+)
+
+select
+    {%- set all_columns = adapter.get_columns_in_relation(relation) %}
+    {%- for column in all_columns %}
+    {{ column.name }}{% if not loop.last %},{% endif %}
+    {%- endfor %}
+from numbered
+where mod(_rn - {{ start_offset }}, {{ n }}) = 0 and _rn >= {{ start_offset }}
+
+{% endmacro %}
+
+
+{#
+    Macro: sample_random_percent
+    Description: Returns a random percentage of records using table sampling.
+
+    Alteryx Equivalent: Random % Sample mode
+
+    Arguments:
+        relation: The source relation
+        percent: Percentage of records to sample (0-100)
+        seed: Optional random seed for reproducibility
+
+    Example Usage:
+        {{ sample_random_percent(ref('stg_customers'), 10) }}
+#}
+
+{% macro sample_random_percent(relation, percent, seed=none) %}
+
+select *
+from {{ relation }}
+tablesample bernoulli({{ percent }})
+{% if seed %}
+{# Note: Trino's TABLESAMPLE doesn't support seed directly, using alternative #}
+{% endif %}
+
+{% endmacro %}
+
+
+{#
+    Macro: sample_random_n
+    Description: Returns approximately N random records.
+
+    Alteryx Equivalent: Random N records mode
+
+    Arguments:
+        relation: The source relation
+        n: Approximate number of records to return
+        seed: Optional random seed
+
+    Example Usage:
+        {{ sample_random_n(ref('stg_orders'), 1000) }}
+#}
+
+{% macro sample_random_n(relation, n, seed=none) %}
+
+with counted as (
+    select count(*) as total_count from {{ relation }}
+),
+sampled as (
+    select
+        t.*,
+        random() as _rand
+    from {{ relation }} t
+)
+
+select
+    {%- set all_columns = adapter.get_columns_in_relation(relation) %}
+    {%- for column in all_columns %}
+    {{ column.name }}{% if not loop.last %},{% endif %}
+    {%- endfor %}
+from sampled
+order by _rand
+limit {{ n }}
+
+{% endmacro %}
+
+
+{#
+    Macro: sample_first_n_per_group
+    Description: Returns first N records per group.
+
+    Alteryx Equivalent: Sample tool (First N per group)
+
+    Arguments:
+        relation: The source relation
+        n: Number of records per group
+        group_by: Columns defining groups
+        order_by: Columns to order by within groups
+        order_direction: 'asc' or 'desc' (default: 'asc')
+
+    Example Usage:
+        {{ sample_first_n_per_group(
+            relation=ref('stg_orders'),
+            n=5,
+            group_by=['customer_id'],
+            order_by=['order_date'],
+            order_direction='desc'
+        ) }}
+#}
+
+{% macro sample_first_n_per_group(relation, n, group_by, order_by, order_direction='asc') %}
+
+with ranked as (
+    select
+        *,
+        row_number() over (
+            partition by {{ group_by | join(', ') }}
+            order by {{ order_by | join(' ' ~ order_direction ~ ', ') }} {{ order_direction }}
+        ) as _group_rank
+    from {{ relation }}
+)
+
+select
+    {%- set all_columns = adapter.get_columns_in_relation(relation) %}
+    {%- for column in all_columns %}
+    {{ column.name }}{% if not loop.last %},{% endif %}
+    {%- endfor %}
+from ranked
+where _group_rank <= {{ n }}
+
+{% endmacro %}
+
+
+{#
+    Macro: select_records_by_range
+    Description: Selects records by row number range.
+
+    Alteryx Equivalent: Select Records tool
+
+    Arguments:
+        relation: The source relation
+        start_row: Starting row number (1-indexed, inclusive)
+        end_row: Ending row number (inclusive, or null for no limit)
+        order_by: Optional columns to order by (defines row order)
+
+    Example Usage:
+        {{ select_records_by_range(ref('stg_data'), 100, 200, order_by=['id']) }}
+#}
+
+{% macro select_records_by_range(relation, start_row, end_row=none, order_by=none) %}
+
+with numbered as (
+    select
+        *,
+        row_number() over (
+            {% if order_by %}order by {{ order_by | join(', ') }}{% else %}order by (select null){% endif %}
+        ) as _rn
+    from {{ relation }}
+)
+
+select
+    {%- set all_columns = adapter.get_columns_in_relation(relation) %}
+    {%- for column in all_columns %}
+    {{ column.name }}{% if not loop.last %},{% endif %}
+    {%- endfor %}
+from numbered
+where _rn >= {{ start_row }}
+{% if end_row %}
+and _rn <= {{ end_row }}
+{% endif %}
+
+{% endmacro %}
+
+
+{#
+    Macro: select_records_by_list
+    Description: Selects specific record numbers.
+
+    Alteryx Equivalent: Select Records tool (specific records mode)
+
+    Arguments:
+        relation: The source relation
+        record_numbers: List of row numbers to select (1-indexed)
+        order_by: Optional columns defining row order
+
+    Example Usage:
+        {{ select_records_by_list(ref('stg_data'), [1, 5, 10, 15, 20], order_by=['id']) }}
+#}
+
+{% macro select_records_by_list(relation, record_numbers, order_by=none) %}
+
+with numbered as (
+    select
+        *,
+        row_number() over (
+            {% if order_by %}order by {{ order_by | join(', ') }}{% else %}order by (select null){% endif %}
+        ) as _rn
+    from {{ relation }}
+)
+
+select
+    {%- set all_columns = adapter.get_columns_in_relation(relation) %}
+    {%- for column in all_columns %}
+    {{ column.name }}{% if not loop.last %},{% endif %}
+    {%- endfor %}
+from numbered
+where _rn in ({{ record_numbers | join(', ') }})
+
+{% endmacro %}
+
+
+{#
+    Macro: stratified_sample
+    Description: Returns a proportional sample from each stratum/group.
+
+    Alteryx Equivalent: Stratified sampling pattern
+
+    Arguments:
+        relation: The source relation
+        stratum_column: Column defining strata
+        sample_percent: Percentage to sample from each stratum (0-100)
+
+    Example Usage:
+        {{ stratified_sample(ref('stg_customers'), 'region', 10) }}
+#}
+
+{% macro stratified_sample(relation, stratum_column, sample_percent) %}
+
+with with_random as (
+    select
+        *,
+        row_number() over (partition by {{ stratum_column }} order by random()) as _rn,
+        count(*) over (partition by {{ stratum_column }}) as _stratum_total
+    from {{ relation }}
+)
+
+select
+    {%- set all_columns = adapter.get_columns_in_relation(relation) %}
+    {%- for column in all_columns %}
+    {{ column.name }}{% if not loop.last %},{% endif %}
+    {%- endfor %}
+from with_random
+where _rn <= ceil(_stratum_total * {{ sample_percent }} / 100.0)
+
+{% endmacro %}
+
+
+{#
+    Macro: weighted_sample
+    Description: Samples records with probability proportional to a weight column.
+
+    Alteryx Equivalent: Weighted random sample pattern
+
+    Arguments:
+        relation: The source relation
+        weight_column: Column containing weights
+        n: Number of records to sample
+
+    Example Usage:
+        {{ weighted_sample(ref('stg_products'), 'sales_volume', 100) }}
+#}
+
+{% macro weighted_sample(relation, weight_column, n) %}
+
+with weighted as (
+    select
+        *,
+        -ln(1 - random()) / {{ weight_column }} as _weighted_rand
+    from {{ relation }}
+    where {{ weight_column }} > 0
+)
+
+select
+    {%- set all_columns = adapter.get_columns_in_relation(relation) %}
+    {%- for column in all_columns %}
+    {{ column.name }}{% if not loop.last %},{% endif %}
+    {%- endfor %}
+from weighted
+order by _weighted_rand
+limit {{ n }}
+
+{% endmacro %}

--- a/dbt_macros/select_transform.sql
+++ b/dbt_macros/select_transform.sql
@@ -1,0 +1,380 @@
+{#
+    =============================================================================
+    Select and Transform Macros
+    Alteryx Equivalent: Select tool, Auto Field, Sort tool
+    Trino Compatible: Yes
+    =============================================================================
+
+    These macros provide column selection, renaming, reordering, and sorting
+    functionality similar to Alteryx Select and Sort tools.
+#}
+
+{#
+    Macro: select_columns
+    Description: Selects specific columns from a relation.
+
+    Alteryx Equivalent: Select tool (choosing which columns to include)
+
+    Arguments:
+        relation: The source relation
+        columns: List of column names to include
+        include: If true, include listed columns; if false, exclude them
+
+    Example Usage:
+        {{ select_columns(ref('stg_orders'), ['order_id', 'customer_id', 'amount']) }}
+#}
+
+{% macro select_columns(relation, columns, include=true) %}
+
+select
+    {% if include %}
+    {{ columns | join(',\n    ') }}
+    {% else %}
+    {%- set all_columns = adapter.get_columns_in_relation(relation) %}
+    {%- set excluded = columns | map('lower') | list %}
+    {%- for column in all_columns %}
+        {%- if column.name|lower not in excluded %}
+    {{ column.name }}{% if not loop.last %},{% endif %}
+        {%- endif %}
+    {%- endfor %}
+    {% endif %}
+from {{ relation }}
+
+{% endmacro %}
+
+
+{#
+    Macro: rename_columns
+    Description: Renames columns in a relation.
+
+    Alteryx Equivalent: Select tool (rename functionality)
+
+    Arguments:
+        relation: The source relation
+        renames: Dictionary of old_name: new_name pairs
+
+    Example Usage:
+        {{ rename_columns(
+            relation=ref('stg_orders'),
+            renames={'cust_id': 'customer_id', 'amt': 'amount', 'ord_dt': 'order_date'}
+        ) }}
+#}
+
+{% macro rename_columns(relation, renames) %}
+
+select
+    {%- set all_columns = adapter.get_columns_in_relation(relation) %}
+    {%- for column in all_columns %}
+        {%- if column.name in renames %}
+    {{ column.name }} as {{ renames[column.name] }}
+        {%- else %}
+    {{ column.name }}
+        {%- endif %}
+        {%- if not loop.last %},{% endif %}
+    {%- endfor %}
+from {{ relation }}
+
+{% endmacro %}
+
+
+{#
+    Macro: reorder_columns
+    Description: Reorders columns, with specified columns first.
+
+    Alteryx Equivalent: Select tool (reordering with arrows)
+
+    Arguments:
+        relation: The source relation
+        first_columns: List of columns to appear first (in order)
+        include_rest: Whether to include remaining columns (default: true)
+
+    Example Usage:
+        {{ reorder_columns(
+            relation=ref('stg_orders'),
+            first_columns=['order_id', 'order_date', 'customer_id']
+        ) }}
+#}
+
+{% macro reorder_columns(relation, first_columns, include_rest=true) %}
+
+select
+    {%- for col in first_columns %}
+    {{ col }},
+    {%- endfor %}
+    {% if include_rest %}
+    {%- set all_columns = adapter.get_columns_in_relation(relation) %}
+    {%- set first_lower = first_columns | map('lower') | list %}
+    {%- for column in all_columns %}
+        {%- if column.name|lower not in first_lower %}
+    {{ column.name }}{% if not loop.last %},{% endif %}
+        {%- endif %}
+    {%- endfor %}
+    {% endif %}
+from {{ relation }}
+
+{% endmacro %}
+
+
+{#
+    Macro: select_and_rename
+    Description: Selects specific columns with optional renaming.
+
+    Alteryx Equivalent: Select tool (select and rename in one step)
+
+    Arguments:
+        relation: The source relation
+        columns: Dictionary of source_column: alias pairs (use same name for no rename)
+
+    Example Usage:
+        {{ select_and_rename(
+            relation=ref('stg_raw'),
+            columns={
+                'customer_id': 'customer_id',
+                'cust_name': 'customer_name',
+                'ord_amt': 'order_amount'
+            }
+        ) }}
+#}
+
+{% macro select_and_rename(relation, columns) %}
+
+select
+    {%- for source_col, alias in columns.items() %}
+    {{ source_col }}{% if source_col != alias %} as {{ alias }}{% endif %}{% if not loop.last %},{% endif %}
+    {%- endfor %}
+from {{ relation }}
+
+{% endmacro %}
+
+
+{#
+    Macro: sort_data
+    Description: Sorts data by specified columns.
+
+    Alteryx Equivalent: Sort tool
+
+    Arguments:
+        relation: The source relation
+        order_by: List of columns to sort by (or list of [column, direction] pairs)
+        nulls_position: 'first', 'last', or none (default: none)
+
+    Example Usage:
+        {{ sort_data(
+            relation=ref('stg_orders'),
+            order_by=[['order_date', 'desc'], ['customer_id', 'asc']],
+            nulls_position='last'
+        ) }}
+#}
+
+{% macro sort_data(relation, order_by, nulls_position=none) %}
+
+select *
+from {{ relation }}
+order by
+    {%- for item in order_by %}
+        {%- if item is iterable and item is not string %}
+    {{ item[0] }} {{ item[1] | default('asc') }}{% if nulls_position %} nulls {{ nulls_position }}{% endif %}
+        {%- else %}
+    {{ item }}{% if nulls_position %} nulls {{ nulls_position }}{% endif %}
+        {%- endif %}
+        {%- if not loop.last %},{% endif %}
+    {%- endfor %}
+
+{% endmacro %}
+
+
+{#
+    Macro: add_row_number
+    Description: Adds sequential row number to each row.
+
+    Alteryx Equivalent: RecordID tool
+
+    Arguments:
+        relation: The source relation
+        alias: Name for the row number column (default: 'row_num')
+        partition_by: Optional partition columns
+        order_by: Optional order columns
+        start_value: Starting value (default: 1)
+
+    Example Usage:
+        {{ add_row_number(
+            relation=ref('stg_customers'),
+            alias='customer_sequence',
+            order_by=['created_at']
+        ) }}
+#}
+
+{% macro add_row_number(relation, alias='row_num', partition_by=none, order_by=none, start_value=1) %}
+
+select
+    row_number() over (
+        {% if partition_by %}partition by {{ partition_by | join(', ') }}{% endif %}
+        {% if order_by %}order by {{ order_by | join(', ') }}{% endif %}
+    ){% if start_value != 1 %} + {{ start_value - 1 }}{% endif %} as {{ alias }},
+    *
+from {{ relation }}
+
+{% endmacro %}
+
+
+{#
+    Macro: auto_type_columns
+    Description: Applies type inference/conversion to columns.
+
+    Alteryx Equivalent: Auto Field tool
+
+    Arguments:
+        relation: The source relation
+        type_overrides: Dictionary of column: type pairs for manual type specification
+        string_to_number: Try converting string columns to numbers (default: false)
+        string_to_date: Try converting string columns to dates (default: false)
+
+    Example Usage:
+        {{ auto_type_columns(
+            relation=ref('raw_data'),
+            type_overrides={'order_id': 'bigint', 'amount': 'decimal(18,2)'},
+            string_to_number=true
+        ) }}
+#}
+
+{% macro auto_type_columns(relation, type_overrides={}, string_to_number=false, string_to_date=false) %}
+
+select
+    {%- set all_columns = adapter.get_columns_in_relation(relation) %}
+    {%- for column in all_columns %}
+        {%- if column.name in type_overrides %}
+    try_cast({{ column.name }} as {{ type_overrides[column.name] }}) as {{ column.name }}
+        {%- elif string_to_number and column.is_string() %}
+    coalesce(try_cast({{ column.name }} as double), try_cast({{ column.name }} as bigint), {{ column.name }}) as {{ column.name }}
+        {%- elif string_to_date and column.is_string() %}
+    coalesce(try_cast({{ column.name }} as date), try_cast({{ column.name }} as timestamp), {{ column.name }}) as {{ column.name }}
+        {%- else %}
+    {{ column.name }}
+        {%- endif %}
+        {%- if not loop.last %},{% endif %}
+    {%- endfor %}
+from {{ relation }}
+
+{% endmacro %}
+
+
+{#
+    Macro: prefix_columns
+    Description: Adds a prefix to all or selected column names.
+
+    Alteryx Equivalent: Select tool with dynamic rename
+
+    Arguments:
+        relation: The source relation
+        prefix: Prefix to add
+        columns: Optional list of columns to prefix (all if not specified)
+        exclude: Optional list of columns to exclude from prefixing
+
+    Example Usage:
+        {{ prefix_columns(ref('stg_orders'), 'ord_', exclude=['id']) }}
+#}
+
+{% macro prefix_columns(relation, prefix, columns=none, exclude=[]) %}
+
+select
+    {%- set all_columns = adapter.get_columns_in_relation(relation) %}
+    {%- set cols_to_prefix = columns if columns else all_columns | map(attribute='name') | list %}
+    {%- for column in all_columns %}
+        {%- if column.name in cols_to_prefix and column.name not in exclude %}
+    {{ column.name }} as {{ prefix }}{{ column.name }}
+        {%- else %}
+    {{ column.name }}
+        {%- endif %}
+        {%- if not loop.last %},{% endif %}
+    {%- endfor %}
+from {{ relation }}
+
+{% endmacro %}
+
+
+{#
+    Macro: suffix_columns
+    Description: Adds a suffix to all or selected column names.
+
+    Arguments:
+        relation: The source relation
+        suffix: Suffix to add
+        columns: Optional list of columns to suffix
+        exclude: Optional list of columns to exclude
+
+    Example Usage:
+        {{ suffix_columns(ref('stg_customers'), '_raw', exclude=['customer_id']) }}
+#}
+
+{% macro suffix_columns(relation, suffix, columns=none, exclude=[]) %}
+
+select
+    {%- set all_columns = adapter.get_columns_in_relation(relation) %}
+    {%- set cols_to_suffix = columns if columns else all_columns | map(attribute='name') | list %}
+    {%- for column in all_columns %}
+        {%- if column.name in cols_to_suffix and column.name not in exclude %}
+    {{ column.name }} as {{ column.name }}{{ suffix }}
+        {%- else %}
+    {{ column.name }}
+        {%- endif %}
+        {%- if not loop.last %},{% endif %}
+    {%- endfor %}
+from {{ relation }}
+
+{% endmacro %}
+
+
+{#
+    Macro: drop_columns
+    Description: Drops specified columns from a relation.
+
+    Alteryx Equivalent: Select tool (unchecking columns)
+
+    Arguments:
+        relation: The source relation
+        columns_to_drop: List of column names to remove
+
+    Example Usage:
+        {{ drop_columns(ref('stg_orders'), ['internal_id', 'temp_field', 'debug_info']) }}
+#}
+
+{% macro drop_columns(relation, columns_to_drop) %}
+
+select
+    {%- set all_columns = adapter.get_columns_in_relation(relation) %}
+    {%- set drop_lower = columns_to_drop | map('lower') | list %}
+    {%- for column in all_columns %}
+        {%- if column.name|lower not in drop_lower %}
+    {{ column.name }}{% if not loop.last %},{% endif %}
+        {%- endif %}
+    {%- endfor %}
+from {{ relation }}
+
+{% endmacro %}
+
+
+{#
+    Macro: limit_rows
+    Description: Limits the number of rows returned.
+
+    Alteryx Equivalent: Sample tool (First N records)
+
+    Arguments:
+        relation: The source relation
+        n: Number of rows to return
+        offset: Number of rows to skip (default: 0)
+
+    Example Usage:
+        {{ limit_rows(ref('stg_orders'), 1000, offset=0) }}
+#}
+
+{% macro limit_rows(relation, n, offset=0) %}
+
+select *
+from {{ relation }}
+{% if offset > 0 %}
+offset {{ offset }}
+{% endif %}
+limit {{ n }}
+
+{% endmacro %}

--- a/dbt_macros/tile_bucket.sql
+++ b/dbt_macros/tile_bucket.sql
@@ -1,0 +1,378 @@
+{#
+    =============================================================================
+    Tile and Bucket Macros
+    Alteryx Equivalent: Tile tool
+    Trino Compatible: Yes
+    =============================================================================
+
+    These macros provide data tiling, binning, and bucketing functionality
+    similar to the Alteryx Tile tool.
+#}
+
+{#
+    Macro: tile_equal_records
+    Description: Divides data into N tiles with approximately equal record counts.
+
+    Alteryx Equivalent: Tile tool (Equal Records mode)
+
+    Arguments:
+        relation: The source relation
+        num_tiles: Number of tiles to create
+        order_by: Columns to order by before tiling
+        tile_column: Name for the tile column (default: 'tile')
+        partition_by: Optional partition columns for tiling within groups
+
+    Example Usage:
+        {{ tile_equal_records(
+            relation=ref('stg_customers'),
+            num_tiles=10,
+            order_by=['lifetime_value'],
+            tile_column='value_decile'
+        ) }}
+#}
+
+{% macro tile_equal_records(relation, num_tiles, order_by, tile_column='tile', partition_by=none) %}
+
+select
+    *,
+    ntile({{ num_tiles }}) over (
+        {% if partition_by %}partition by {{ partition_by | join(', ') }}{% endif %}
+        order by {{ order_by | join(', ') }}
+    ) as {{ tile_column }}
+from {{ relation }}
+
+{% endmacro %}
+
+
+{#
+    Macro: tile_equal_sum
+    Description: Divides data into N tiles with approximately equal sum of a value column.
+
+    Alteryx Equivalent: Tile tool (Equal Sum mode)
+
+    Arguments:
+        relation: The source relation
+        num_tiles: Number of tiles to create
+        sum_column: Column to sum for equal distribution
+        order_by: Columns to order by
+        tile_column: Name for the tile column
+
+    Example Usage:
+        {{ tile_equal_sum(
+            relation=ref('stg_orders'),
+            num_tiles=5,
+            sum_column='revenue',
+            order_by=['revenue'],
+            tile_column='revenue_quintile'
+        ) }}
+#}
+
+{% macro tile_equal_sum(relation, num_tiles, sum_column, order_by, tile_column='tile') %}
+
+with running_totals as (
+    select
+        *,
+        sum({{ sum_column }}) over (order by {{ order_by | join(', ') }}) as _running_sum,
+        sum({{ sum_column }}) over () as _total_sum
+    from {{ relation }}
+)
+
+select
+    {%- set all_columns = adapter.get_columns_in_relation(relation) %}
+    {%- for col in all_columns %}
+    {{ col.name }},
+    {%- endfor %}
+    ceil(_running_sum / nullif(_total_sum / {{ num_tiles }}.0, 0)) as {{ tile_column }}
+from running_totals
+
+{% endmacro %}
+
+
+{#
+    Macro: tile_smart
+    Description: Smart tiling that handles edge cases and provides tile metadata.
+
+    Alteryx Equivalent: Tile tool (Smart Tile mode)
+
+    Arguments:
+        relation: The source relation
+        num_tiles: Number of tiles
+        order_by: Columns to order by
+        tile_column: Name for tile column
+        include_sequence: Include sequence number within tile (default: false)
+
+    Example Usage:
+        {{ tile_smart(
+            relation=ref('stg_scores'),
+            num_tiles=4,
+            order_by=['score'],
+            tile_column='quartile',
+            include_sequence=true
+        ) }}
+#}
+
+{% macro tile_smart(relation, num_tiles, order_by, tile_column='tile', include_sequence=false) %}
+
+select
+    *,
+    ntile({{ num_tiles }}) over (order by {{ order_by | join(', ') }}) as {{ tile_column }}
+    {%- if include_sequence %},
+    row_number() over (
+        partition by ntile({{ num_tiles }}) over (order by {{ order_by | join(', ') }})
+        order by {{ order_by | join(', ') }}
+    ) as {{ tile_column }}_sequence
+    {%- endif %}
+from {{ relation }}
+
+{% endmacro %}
+
+
+{#
+    Macro: bucket_fixed_width
+    Description: Creates buckets of fixed width.
+
+    Alteryx Equivalent: Tile tool (Fixed Width mode)
+
+    Arguments:
+        column: Column to bucket
+        bucket_width: Width of each bucket
+        min_value: Minimum value (optional, uses column min)
+        bucket_column: Name for bucket column (default: uses formula)
+
+    Example Usage:
+        {{ bucket_fixed_width('age', 10) }}
+        -- Returns bucket label like '20-30', '30-40', etc.
+#}
+
+{% macro bucket_fixed_width(column, bucket_width, min_value=0) %}
+concat(
+    cast(floor(({{ column }} - {{ min_value }}) / {{ bucket_width }}) * {{ bucket_width }} + {{ min_value }} as varchar),
+    '-',
+    cast(floor(({{ column }} - {{ min_value }}) / {{ bucket_width }}) * {{ bucket_width }} + {{ min_value }} + {{ bucket_width }} as varchar)
+)
+{% endmacro %}
+
+
+{#
+    Macro: bucket_fixed_width_numeric
+    Description: Returns numeric bucket ID for fixed-width buckets.
+
+    Arguments:
+        column: Column to bucket
+        bucket_width: Width of each bucket
+        min_value: Minimum value (default: 0)
+
+    Example Usage:
+        {{ bucket_fixed_width_numeric('income', 10000) }} as income_bucket
+#}
+
+{% macro bucket_fixed_width_numeric(column, bucket_width, min_value=0) %}
+floor(({{ column }} - {{ min_value }}) / {{ bucket_width }}) + 1
+{% endmacro %}
+
+
+{#
+    Macro: bucket_custom_ranges
+    Description: Creates buckets based on custom-defined ranges.
+
+    Alteryx Equivalent: Tile tool (Manual mode)
+
+    Arguments:
+        column: Column to bucket
+        ranges: List of [lower_bound, upper_bound, label] tuples
+        default_label: Label for values outside all ranges
+
+    Example Usage:
+        {{ bucket_custom_ranges(
+            'score',
+            ranges=[
+                [0, 59, 'F'],
+                [60, 69, 'D'],
+                [70, 79, 'C'],
+                [80, 89, 'B'],
+                [90, 100, 'A']
+            ],
+            default_label='Invalid'
+        ) }}
+#}
+
+{% macro bucket_custom_ranges(column, ranges, default_label='Other') %}
+case
+    {%- for range in ranges %}
+    when {{ column }} >= {{ range[0] }} and {{ column }} <= {{ range[1] }} then '{{ range[2] }}'
+    {%- endfor %}
+    else '{{ default_label }}'
+end
+{% endmacro %}
+
+
+{#
+    Macro: quantile_buckets
+    Description: Creates buckets based on quantiles (percentiles).
+
+    Alteryx Equivalent: Tile tool for percentile-based grouping
+
+    Arguments:
+        relation: Source relation
+        column: Column to bucket
+        quantiles: List of percentile cutpoints (e.g., [0.25, 0.5, 0.75])
+        bucket_column: Name for bucket column
+        labels: Optional list of labels (should be len(quantiles) + 1)
+
+    Example Usage:
+        {{ quantile_buckets(
+            relation=ref('stg_incomes'),
+            column='income',
+            quantiles=[0.25, 0.5, 0.75],
+            bucket_column='income_quartile',
+            labels=['Low', 'Below Median', 'Above Median', 'High']
+        ) }}
+#}
+
+{% macro quantile_buckets(relation, column, quantiles, bucket_column='quantile_bucket', labels=none) %}
+
+with percentile_values as (
+    select
+        {%- for q in quantiles %}
+        approx_percentile({{ column }}, {{ q }}) as _p{{ loop.index }}{% if not loop.last %},{% endif %}
+        {%- endfor %}
+    from {{ relation }}
+    where {{ column }} is not null
+)
+
+select
+    t.*,
+    case
+        {%- for q in quantiles %}
+        when t.{{ column }} <= p._p{{ loop.index }}
+            then {% if labels %}'{{ labels[loop.index0] }}'{% else %}{{ loop.index }}{% endif %}
+        {%- endfor %}
+        else {% if labels %}'{{ labels[-1] }}'{% else %}{{ quantiles | length + 1 }}{% endif %}
+    end as {{ bucket_column }}
+from {{ relation }} t
+cross join percentile_values p
+
+{% endmacro %}
+
+
+{#
+    Macro: bin_numeric
+    Description: Bins numeric values into specified number of equal-width bins.
+
+    Alteryx Equivalent: Tile tool (Equal Interval mode)
+
+    Arguments:
+        relation: Source relation
+        column: Column to bin
+        num_bins: Number of bins to create
+        bin_column: Name for bin column
+
+    Example Usage:
+        {{ bin_numeric(ref('stg_measurements'), 'temperature', 10, 'temp_bin') }}
+#}
+
+{% macro bin_numeric(relation, column, num_bins, bin_column='bin') %}
+
+with stats as (
+    select
+        min({{ column }}) as _min_val,
+        max({{ column }}) as _max_val,
+        (max({{ column }}) - min({{ column }})) / {{ num_bins }}.0 as _bin_width
+    from {{ relation }}
+    where {{ column }} is not null
+)
+
+select
+    t.*,
+    case
+        when t.{{ column }} = s._max_val then {{ num_bins }}
+        else least(floor((t.{{ column }} - s._min_val) / nullif(s._bin_width, 0)) + 1, {{ num_bins }})
+    end as {{ bin_column }}
+from {{ relation }} t
+cross join stats s
+
+{% endmacro %}
+
+
+{#
+    Macro: percentile_rank
+    Description: Calculates the percentile rank of each row.
+
+    Alteryx Equivalent: Tile tool output with percentage
+
+    Arguments:
+        relation: Source relation
+        order_by: Columns to order by
+        rank_column: Name for the rank column
+        partition_by: Optional partition columns
+
+    Example Usage:
+        {{ percentile_rank(ref('stg_sales'), ['revenue'], 'revenue_percentile') }}
+#}
+
+{% macro percentile_rank(relation, order_by, rank_column='percentile_rank', partition_by=none) %}
+
+select
+    *,
+    percent_rank() over (
+        {% if partition_by %}partition by {{ partition_by | join(', ') }}{% endif %}
+        order by {{ order_by | join(', ') }}
+    ) * 100 as {{ rank_column }}
+from {{ relation }}
+
+{% endmacro %}
+
+
+{#
+    Macro: cume_dist
+    Description: Calculates cumulative distribution of values.
+
+    Alteryx Equivalent: Related to tile tool percentage calculations
+
+    Arguments:
+        relation: Source relation
+        order_by: Columns to order by
+        dist_column: Name for the distribution column
+        partition_by: Optional partition columns
+
+    Example Usage:
+        {{ cume_dist(ref('stg_scores'), ['score'], 'cumulative_pct') }}
+#}
+
+{% macro cume_dist(relation, order_by, dist_column='cume_dist', partition_by=none) %}
+
+select
+    *,
+    cume_dist() over (
+        {% if partition_by %}partition by {{ partition_by | join(', ') }}{% endif %}
+        order by {{ order_by | join(', ') }}
+    ) as {{ dist_column }}
+from {{ relation }}
+
+{% endmacro %}
+
+
+{#
+    Macro: assign_tile_by_value
+    Description: Assigns tiles based on specific value boundaries.
+
+    Alteryx Equivalent: Tile tool with manual cutpoints
+
+    Arguments:
+        column: Column to tile
+        cutpoints: List of boundary values [c1, c2, c3, ...]
+                   Creates tiles: <=c1, c1<x<=c2, c2<x<=c3, >c3
+
+    Example Usage:
+        {{ assign_tile_by_value('revenue', [1000, 5000, 10000, 50000]) }}
+#}
+
+{% macro assign_tile_by_value(column, cutpoints) %}
+case
+    when {{ column }} <= {{ cutpoints[0] }} then 1
+    {%- for i in range(1, cutpoints | length) %}
+    when {{ column }} <= {{ cutpoints[i] }} then {{ i + 1 }}
+    {%- endfor %}
+    else {{ cutpoints | length + 1 }}
+end
+{% endmacro %}


### PR DESCRIPTION
This commit adds 12 new macro files providing Trino-compatible implementations
for all Alteryx preparation tool patterns:

- filter_helpers.sql: Filter tool equivalents (by expression, range, regex, etc.)
- formula_helpers.sql: Formula tool (IIF, Switch, string functions, etc.)
- select_transform.sql: Select tool (column selection, renaming, reordering, etc.)
- sample_limit.sql: Sample tool (first N, random, stratified sampling, etc.)
- find_replace.sql: Find Replace tool (pattern matching, lookup replacement)
- imputation.sql: Imputation tool (mean, median, mode, forward/backward fill)
- tile_bucket.sql: Tile tool (equal records, quantiles, custom ranges)
- aggregation.sql: Summarize tool (all aggregation functions)
- math_functions.sql: Math functions (abs, round, sqrt, trig, etc.)
- regex_functions.sql: RegEx tool (match, extract, replace, tokenize)
- conditional_logic.sql: Conditional logic (CASE, categorization, flags)
- join_union.sql: Join/Union tools (inner, left, anti-join, union, etc.)

Each macro includes:
- Comprehensive documentation with Alteryx equivalent
- Example usage patterns
- Trino-compatible SQL syntax

https://claude.ai/code/session_011LzoNCxqbMAjuwcJAiaCH4