### PR TITLE
Fix data_type not added to _sources.yml when CSV read via resolved path

### DIFF
--- a/dbt_generator.py
+++ b/dbt_generator.py
@@ -825,7 +825,12 @@ class DBTGenerator:
                 # If we still have columns without types, try to infer from the source file
                 columns_missing_types = [c for c in columns if c not in column_types]
                 if columns_missing_types:
-                    source_path = node.source_path or node.table_name or ""
+                    source_key = f"{schema}.{table}"
+                    # Prefer the resolved file path (from successful file read or
+                    # interactive prompt) over the original Alteryx path which may
+                    # not exist on this system (e.g. Windows UNC paths on Linux).
+                    resolved_path = self._resolved_source_files.get(source_key, "")
+                    source_path = resolved_path or node.source_path or node.table_name or ""
                     if source_path:
                         inferred_types = self._infer_file_column_types(source_path)
                         for col, dtype in inferred_types.items():
@@ -864,6 +869,7 @@ class DBTGenerator:
         if source_path:
             columns = self._read_file_columns(source_path)
             if columns:
+                self._resolved_source_files[source_key] = source_path
                 return columns
 
         # If interactive mode, prompt user for the file location

--- a/tests/test_source_columns.py
+++ b/tests/test_source_columns.py
@@ -104,6 +104,122 @@ class TestFileColumnDispatcher:
         assert len(json_cols) == 6
 
 
+class TestDataTypeInference:
+    """Tests for data_type attribute in _sources.yml generation."""
+
+    def _make_workflow_with_source(self, source_path, table_name=None):
+        """Helper to create a minimal workflow with one Input source node."""
+        from models import AlteryxNode, AlteryxWorkflow, WorkflowMetadata, ToolCategory
+        node = AlteryxNode(
+            tool_id=1,
+            tool_type="AlteryxBasePluginsGui.DbFileInput.DbFileInput",
+            plugin_name="Input Data",
+            category=ToolCategory.INPUT,
+            source_path=source_path,
+            table_name=table_name,
+        )
+        workflow = AlteryxWorkflow(
+            metadata=WorkflowMetadata(name="test_wf", file_path="test.yxmd"),
+            nodes=[node],
+            connections=[],
+            sources=[node],
+        )
+        return workflow
+
+    def test_data_type_from_real_csv(self, test_data_dir):
+        """Test that data_type attributes are added when a real CSV exists."""
+        csv_path = os.path.join(test_data_dir, 'sample_customers.csv')
+        workflow = self._make_workflow_with_source(csv_path)
+
+        output_dir = tempfile.mkdtemp()
+        gen = DBTGenerator(output_dir, interactive=False)
+        gen._collect_sources([workflow])
+
+        # Verify column_types were inferred for the source
+        assert len(gen.sources) > 0
+        for schema, tables in gen.sources.items():
+            for table_name, source_info in tables.items():
+                assert len(source_info.columns) > 0, "Columns should be detected from CSV"
+                assert len(source_info.column_types) > 0, "Column types should be inferred from CSV"
+                for col in source_info.columns:
+                    assert col in source_info.column_types, (
+                        f"Column '{col}' missing data_type in column_types"
+                    )
+
+    def test_data_type_written_to_sources_yml(self, test_data_dir):
+        """Test that data_type attributes appear in the generated _sources.yml."""
+        csv_path = os.path.join(test_data_dir, 'sample_customers.csv')
+        workflow = self._make_workflow_with_source(csv_path)
+
+        output_dir = tempfile.mkdtemp()
+        gen = DBTGenerator(output_dir, interactive=False)
+        gen._collect_sources([workflow])
+        gen._generate_sources_yml()
+
+        sources_yml = os.path.join(output_dir, 'models', 'bronze', '_sources.yml')
+        assert os.path.exists(sources_yml), "_sources.yml should be generated"
+
+        with open(sources_yml, 'r') as f:
+            content = f.read()
+
+        assert 'data_type:' in content, (
+            "_sources.yml should contain data_type attributes when a real CSV is provided"
+        )
+        # Verify specific expected types from sample_customers.csv
+        assert 'INTEGER' in content, "customer_id should be inferred as INTEGER"
+        assert 'VARCHAR' in content, "String columns should be inferred as VARCHAR"
+
+    def test_data_type_with_resolved_path(self, test_data_dir):
+        """Test that data_type works when source uses resolved path (not original Alteryx path)."""
+        csv_path = os.path.join(test_data_dir, 'sample_customers.csv')
+        # Simulate an Alteryx workflow pointing to a non-existent Windows path
+        workflow = self._make_workflow_with_source(
+            source_path=r"C:\NonExistent\customers.csv",
+            table_name="customers",
+        )
+
+        output_dir = tempfile.mkdtemp()
+        gen = DBTGenerator(output_dir, interactive=False)
+
+        # Manually resolve the source file (simulates interactive prompt resolution)
+        source_node = workflow.sources[0]
+        schema = gen._get_schema_name(source_node)
+        table = gen._get_table_name(source_node)
+        source_key = f"{schema}.{table}"
+        gen._resolved_source_files[source_key] = csv_path
+
+        # Read columns from the resolved CSV path
+        columns = gen._read_file_columns(csv_path)
+        assert len(columns) > 0
+
+        # Now collect sources - type inference should use the resolved path
+        gen._collect_sources([workflow])
+
+        for s_tables in gen.sources.values():
+            for source_info in s_tables.values():
+                if source_info.columns:
+                    assert len(source_info.column_types) > 0, (
+                        "Column types should be inferred via resolved path even when "
+                        "node.source_path points to a non-existent file"
+                    )
+                    for col in source_info.columns:
+                        assert col in source_info.column_types, (
+                            f"Column '{col}' missing data_type when using resolved path"
+                        )
+
+    def test_inferred_types_are_correct_for_csv(self, generator, test_data_dir):
+        """Test that inferred types from the sample CSV are reasonable."""
+        csv_path = os.path.join(test_data_dir, 'sample_customers.csv')
+        types = generator._infer_file_column_types(csv_path)
+
+        assert types.get('customer_id') == 'INTEGER', "customer_id should be INTEGER"
+        assert types.get('customer_name') == 'VARCHAR', "customer_name should be VARCHAR"
+        assert types.get('email') == 'VARCHAR', "email should be VARCHAR"
+        assert types.get('region') == 'VARCHAR', "region should be VARCHAR"
+        assert types.get('created_date') == 'DATE', "created_date should be DATE"
+        assert types.get('is_active') == 'BOOLEAN', "is_active should be BOOLEAN"
+
+
 class TestErrorHandling:
     """Tests for error handling in column reading."""
 


### PR DESCRIPTION
The type inference in _collect_sources always used node.source_path (the
original Alteryx workflow path, often a Windows UNC path) for inferring
column types. When the actual CSV was read via a different resolved path
(e.g. from interactive prompt), the type inference would fail silently
because the original path doesn't exist on the current system.

Now _try_read_source_columns stores the resolved path on successful file
reads, and _collect_sources prefers the resolved path for type inference.

https://claude.ai/code/session_01FUcCDpH9uo613ct76AoPpN