### PR TITLE
Treat Dynamic Input tools with filenames as data sources

### DIFF
--- a/alteryx_parser.py
+++ b/alteryx_parser.py
@@ -52,6 +52,13 @@ class AlteryxParser:
         workflow.sources = [n for n in nodes if n.category == ToolCategory.INPUT]
         workflow.targets = [n for n in nodes if n.category == ToolCategory.OUTPUT]
 
+        # Also include Dynamic Input nodes with filenames as sources
+        for n in nodes:
+            if (n.plugin_name == "Dynamic Input/Output"
+                    and n.source_path
+                    and n not in workflow.sources):
+                workflow.sources.append(n)
+
         # Identify macros
         for node in nodes:
             if node.is_macro and node.macro_path:
@@ -315,6 +322,8 @@ class AlteryxParser:
             self._parse_sort_config(config_elem, node, config)
         elif node.plugin_name == "Union":
             self._parse_union_config(config_elem, node, config)
+        elif node.plugin_name == "Dynamic Input/Output":
+            self._parse_dynamic_input_config(config_elem, node, config)
 
         return config
 
@@ -415,6 +424,73 @@ class AlteryxParser:
             config['sql'] = node.sql_query
 
         # Also check for queries in different locations
+        query_alt = config_elem.find('.//Query')
+        if query_alt is not None and query_alt.text:
+            node.sql_query = query_alt.text
+            config['sql'] = node.sql_query
+
+        # Parse RecordInfo/Field elements for column type metadata
+        field_types = {}
+        for record_info in config_elem.findall('.//RecordInfo'):
+            for field_elem in record_info.findall('Field'):
+                fname = field_elem.get('name', '')
+                ftype = field_elem.get('type', '')
+                if fname and ftype:
+                    field_types[fname] = ftype
+        if field_types:
+            config['field_types'] = field_types
+
+    def _parse_dynamic_input_config(self, config_elem: ET.Element, node: AlteryxNode, config: Dict):
+        """Parse Dynamic Input tool configuration to extract source filename.
+
+        Dynamic Input tools read from files whose paths may be specified in the
+        tool configuration or supplied dynamically at runtime.  When a filename
+        is present in the configuration we treat it as a data source so that the
+        migration pipeline generates the appropriate bronze/staging models.
+        """
+        # Check <File> element (same pattern as regular Input Data tools)
+        file_elem = config_elem.find('.//File')
+        if file_elem is not None:
+            file_path = file_elem.text or file_elem.get('OutputFileName', '') or file_elem.get('FileName', '')
+            if file_path:
+                node.source_path = file_path
+                config['file_path'] = file_path
+
+        # Check <FileName> element (text content or attribute)
+        if not node.source_path:
+            filename_elem = config_elem.find('.//FileName')
+            if filename_elem is not None:
+                file_path = filename_elem.text or filename_elem.get('FileName', '')
+                if file_path:
+                    node.source_path = file_path
+                    config['file_path'] = file_path
+
+        # Check <TemplateFile> element
+        if not node.source_path:
+            template_elem = config_elem.find('.//TemplateFile')
+            if template_elem is not None and template_elem.text:
+                node.source_path = template_elem.text
+                config['file_path'] = template_elem.text
+
+        # Connection string (Dynamic Input can also reference databases)
+        conn_elem = config_elem.find('.//Connection')
+        if conn_elem is not None:
+            node.connection_string = conn_elem.text
+            config['connection'] = node.connection_string
+            self._parse_connection_string(node.connection_string, node, config)
+
+        # Table name
+        table_elem = config_elem.find('.//Table')
+        if table_elem is not None:
+            node.table_name = table_elem.text
+            config['table'] = node.table_name
+
+        # SQL query
+        query_elem = config_elem.find('.//SQLStatement')
+        if query_elem is not None and query_elem.text:
+            node.sql_query = query_elem.text
+            config['sql'] = node.sql_query
+
         query_alt = config_elem.find('.//Query')
         if query_alt is not None and query_alt.text:
             node.sql_query = query_alt.text

--- a/dbt_generator.py
+++ b/dbt_generator.py
@@ -146,6 +146,18 @@ class DBTGenerator:
             on_missing_dependency=self._handle_missing_column_dependency
         )
 
+    def _is_source_node(self, node: AlteryxNode) -> bool:
+        """Check if a node acts as a data source.
+
+        Returns True for regular INPUT tools as well as Dynamic Input tools
+        that have an associated filename (treated as sources per migration rules).
+        """
+        if node.category == ToolCategory.INPUT:
+            return True
+        if node.plugin_name == "Dynamic Input/Output" and node.source_path:
+            return True
+        return False
+
     def _handle_missing_column_dependency(self, dependency: str, context: str) -> None:
         """Handle missing dependencies reported by ColumnDetector."""
         self._add_todo(
@@ -544,7 +556,7 @@ class DBTGenerator:
             elif node.plugin_name == "Macro Output":
                 output_name = node.annotation or node.configuration.get('Name', f'output_{node.tool_id}')
                 outputs.append({'name': self._sanitize_name(output_name), 'node': node})
-            elif node.category not in [ToolCategory.INPUT, ToolCategory.OUTPUT]:
+            elif not self._is_source_node(node) and node.category != ToolCategory.OUTPUT:
                 transform_nodes.append(node)
 
         # Build macro parameters from inputs
@@ -1198,8 +1210,8 @@ class DBTGenerator:
         upstream_columns = list(dict.fromkeys(upstream_columns))
 
         # Now apply this node's transformation
-        if node.category == ToolCategory.INPUT:
-            # Input nodes: get columns from source
+        if self._is_source_node(node):
+            # Input / Dynamic Input nodes: get columns from source
             columns = self._extract_columns_from_node(node)
 
         elif node.plugin_name == "Select":
@@ -1681,7 +1693,7 @@ class DBTGenerator:
         # Generate bronze models (staging)
         bronze_nodes = medallion.get(MedallionLayer.BRONZE.value, [])
         for node in bronze_nodes:
-            if node.category == ToolCategory.INPUT:
+            if self._is_source_node(node):
                 self._generate_bronze_model(node, workflow_prefix)
 
         # Generate silver models (intermediate) - aggregate sequential transforms
@@ -2053,7 +2065,7 @@ class DBTGenerator:
 
     def _get_model_reference(self, node: AlteryxNode, workflow_prefix: str) -> str:
         """Get the model name to reference for a node."""
-        if node.category == ToolCategory.INPUT:
+        if self._is_source_node(node):
             table = self._get_table_name(node)
             return f"stg_{workflow_prefix}_{table}"
         else:

--- a/doc_generator.py
+++ b/doc_generator.py
@@ -415,7 +415,8 @@ class DocumentationGenerator:
             label = label[:37] + "..."
 
         # Style based on category
-        if node.category == ToolCategory.INPUT:
+        if node.category == ToolCategory.INPUT or (
+                node.plugin_name == "Dynamic Input/Output" and node.source_path):
             return f'{node_id}[("{label}")]'
         elif node.category == ToolCategory.OUTPUT:
             return f'{node_id}[["{label}"]]'

--- a/tests/test_dynamic_input.py
+++ b/tests/test_dynamic_input.py
@@ -1,0 +1,215 @@
+"""
+Tests for Dynamic Input tool filename-as-source detection.
+
+Verifies that when a Dynamic Input tool has a filename in its configuration,
+the parser treats it as a data source and downstream modules handle it correctly.
+"""
+import os
+import sys
+import tempfile
+import textwrap
+
+import pytest
+
+# Add parent directory to path
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from alteryx_parser import AlteryxParser
+from models import AlteryxNode, AlteryxWorkflow, AlteryxConnection, WorkflowMetadata, ToolCategory
+from dbt_generator import DBTGenerator
+
+
+def _make_workflow_xml(file_path: str) -> str:
+    """Build a minimal Alteryx workflow XML containing a Dynamic Input tool."""
+    return textwrap.dedent(f"""\
+        <?xml version="1.0"?>
+        <AlteryxDocument yxmdVer="2023.1">
+          <Properties>
+            <MetaInfo>
+              <Name>DynamicInputTest</Name>
+            </MetaInfo>
+          </Properties>
+          <Nodes>
+            <Node ToolID="1">
+              <GuiSettings Plugin="AlteryxBasePluginsGui.Dynamic.Dynamic">
+                <Position x="100" y="100" />
+              </GuiSettings>
+              <Properties>
+                <Configuration>
+                  <File>{file_path}</File>
+                  <RecordInfo>
+                    <Field name="id" type="Int32" />
+                    <Field name="name" type="V_WString" />
+                  </RecordInfo>
+                </Configuration>
+                <Annotation>
+                  <DefaultAnnotationText>Dynamic CSV</DefaultAnnotationText>
+                </Annotation>
+              </Properties>
+            </Node>
+            <Node ToolID="2">
+              <GuiSettings Plugin="AlteryxBasePluginsGui.BrowseV2.BrowseV2">
+                <Position x="300" y="100" />
+              </GuiSettings>
+              <Properties>
+                <Configuration />
+              </Properties>
+            </Node>
+          </Nodes>
+          <Connections>
+            <Connection>
+              <Origin ToolID="1" Connection="Output" />
+              <Destination ToolID="2" Connection="Input" />
+            </Connection>
+          </Connections>
+        </AlteryxDocument>
+    """)
+
+
+def _make_workflow_xml_no_file() -> str:
+    """Build a workflow XML with a Dynamic Input tool that has no filename."""
+    return textwrap.dedent("""\
+        <?xml version="1.0"?>
+        <AlteryxDocument yxmdVer="2023.1">
+          <Properties>
+            <MetaInfo>
+              <Name>DynamicInputNoFile</Name>
+            </MetaInfo>
+          </Properties>
+          <Nodes>
+            <Node ToolID="1">
+              <GuiSettings Plugin="AlteryxBasePluginsGui.Dynamic.Dynamic">
+                <Position x="100" y="100" />
+              </GuiSettings>
+              <Properties>
+                <Configuration />
+              </Properties>
+            </Node>
+          </Nodes>
+          <Connections />
+        </AlteryxDocument>
+    """)
+
+
+class TestDynamicInputParser:
+    """Test that the parser extracts filenames from Dynamic Input tools."""
+
+    def test_dynamic_input_with_file_is_source(self, tmp_path):
+        """Dynamic Input with a <File> element should appear in workflow.sources."""
+        xml = _make_workflow_xml("C:\\\\data\\\\customers.csv")
+        wf_file = tmp_path / "test.yxmd"
+        wf_file.write_text(xml)
+
+        parser = AlteryxParser()
+        workflow = parser.parse(str(wf_file))
+
+        # The Dynamic Input node should be in sources
+        source_ids = [n.tool_id for n in workflow.sources]
+        assert 1 in source_ids, "Dynamic Input node with filename should be a source"
+
+    def test_dynamic_input_source_path_extracted(self, tmp_path):
+        """The source_path should be extracted from the Dynamic Input config."""
+        xml = _make_workflow_xml("C:/data/customers.csv")
+        wf_file = tmp_path / "test.yxmd"
+        wf_file.write_text(xml)
+
+        parser = AlteryxParser()
+        workflow = parser.parse(str(wf_file))
+
+        dynamic_node = workflow.get_node_by_id(1)
+        assert dynamic_node is not None
+        assert dynamic_node.source_path == "C:/data/customers.csv"
+
+    def test_dynamic_input_without_file_not_source(self, tmp_path):
+        """Dynamic Input without a filename should NOT appear in workflow.sources."""
+        xml = _make_workflow_xml_no_file()
+        wf_file = tmp_path / "test.yxmd"
+        wf_file.write_text(xml)
+
+        parser = AlteryxParser()
+        workflow = parser.parse(str(wf_file))
+
+        source_ids = [n.tool_id for n in workflow.sources]
+        assert 1 not in source_ids, "Dynamic Input without filename should not be a source"
+
+    def test_dynamic_input_category_is_parse(self, tmp_path):
+        """Dynamic Input should retain its PARSE category."""
+        xml = _make_workflow_xml("C:\\\\data\\\\customers.csv")
+        wf_file = tmp_path / "test.yxmd"
+        wf_file.write_text(xml)
+
+        parser = AlteryxParser()
+        workflow = parser.parse(str(wf_file))
+
+        dynamic_node = workflow.get_node_by_id(1)
+        assert dynamic_node.category == ToolCategory.PARSE
+
+    def test_dynamic_input_field_types_extracted(self, tmp_path):
+        """RecordInfo/Field elements should be parsed for Dynamic Input."""
+        xml = _make_workflow_xml("data.csv")
+        wf_file = tmp_path / "test.yxmd"
+        wf_file.write_text(xml)
+
+        parser = AlteryxParser()
+        workflow = parser.parse(str(wf_file))
+
+        dynamic_node = workflow.get_node_by_id(1)
+        field_types = dynamic_node.configuration.get('field_types', {})
+        assert 'id' in field_types
+        assert 'name' in field_types
+
+
+class TestDynamicInputDBTGenerator:
+    """Test that the DBT generator treats Dynamic Input filenames as sources."""
+
+    def test_is_source_node_dynamic_input(self):
+        """_is_source_node should return True for Dynamic Input with source_path."""
+        gen = DBTGenerator(tempfile.mkdtemp(), interactive=False)
+
+        node = AlteryxNode(
+            tool_id=1,
+            tool_type="AlteryxBasePluginsGui.Dynamic.Dynamic",
+            plugin_name="Dynamic Input/Output",
+            category=ToolCategory.PARSE,
+            source_path="data/orders.csv",
+        )
+        assert gen._is_source_node(node) is True
+
+    def test_is_source_node_dynamic_input_no_path(self):
+        """_is_source_node should return False for Dynamic Input without source_path."""
+        gen = DBTGenerator(tempfile.mkdtemp(), interactive=False)
+
+        node = AlteryxNode(
+            tool_id=1,
+            tool_type="AlteryxBasePluginsGui.Dynamic.Dynamic",
+            plugin_name="Dynamic Input/Output",
+            category=ToolCategory.PARSE,
+        )
+        assert gen._is_source_node(node) is False
+
+    def test_is_source_node_regular_input(self):
+        """_is_source_node should return True for regular INPUT tools."""
+        gen = DBTGenerator(tempfile.mkdtemp(), interactive=False)
+
+        node = AlteryxNode(
+            tool_id=1,
+            tool_type="AlteryxBasePluginsGui.DbFileInput.DbFileInput",
+            plugin_name="Input Data",
+            category=ToolCategory.INPUT,
+        )
+        assert gen._is_source_node(node) is True
+
+    def test_get_model_reference_dynamic_input(self):
+        """Dynamic Input source should get a stg_ model reference."""
+        gen = DBTGenerator(tempfile.mkdtemp(), interactive=False)
+
+        node = AlteryxNode(
+            tool_id=1,
+            tool_type="AlteryxBasePluginsGui.Dynamic.Dynamic",
+            plugin_name="Dynamic Input/Output",
+            category=ToolCategory.PARSE,
+            source_path="data/orders.csv",
+        )
+        ref = gen._get_model_reference(node, "test_wf")
+        assert ref.startswith("stg_"), f"Expected stg_ prefix, got: {ref}"
+        assert "orders" in ref, f"Expected 'orders' in reference, got: {ref}"

--- a/transformation_analyzer.py
+++ b/transformation_analyzer.py
@@ -101,7 +101,8 @@ class TransformationAnalyzer:
         """Generate a human-readable description of a transformation step."""
         desc_parts = [node.plugin_name]
 
-        if node.category == ToolCategory.INPUT:
+        if node.category == ToolCategory.INPUT or (
+                node.plugin_name == "Dynamic Input/Output" and node.source_path):
             if node.source_path:
                 desc_parts.append(f"from '{node.source_path}'")
             elif node.table_name:
@@ -168,7 +169,8 @@ class TransformationAnalyzer:
 
         sql_template = mapping.get('sql', '-- Custom logic required')
 
-        if node.category == ToolCategory.INPUT:
+        if node.category == ToolCategory.INPUT or (
+                node.plugin_name == "Dynamic Input/Output" and node.source_path):
             if node.table_name:
                 return f"{{{{ source('schema', '{node.table_name}') }}}}"
             elif node.source_path:


### PR DESCRIPTION
When a Dynamic Input tool in an Alteryx workflow has a filename in its
configuration, it is now recognized as a data source. This ensures that
the parser includes it in workflow.sources and downstream modules
(DBT generator, transformation analyzer, doc generator) create the
appropriate bronze/staging models, lineage tracking, and documentation.

Changes:
- alteryx_parser: parse Dynamic Input config for file/connection info,
  add nodes with filenames to workflow.sources
- dbt_generator: add _is_source_node() helper; use it for bronze model
  generation, column extraction, and model references
- transformation_analyzer: generate source descriptions and SQL hints
  for Dynamic Input nodes
- doc_generator: render Dynamic Input sources with input-style Mermaid
  node shape
- tests: add 9 tests covering parser extraction and DBT generator logic

https://claude.ai/code/session_01SaPNDrhJAdGcnxpmgztzg5